### PR TITLE
fix terminally deprecated API

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
@@ -44,8 +44,8 @@ import matsyir.pvpperformancetracker.models.RingData;
 import net.runelite.api.PlayerComposition;
 import net.runelite.api.SpriteID;
 import net.runelite.api.kit.KitType;
-import net.runelite.http.api.item.ItemEquipmentStats;
-import net.runelite.http.api.item.ItemStats;
+import net.runelite.client.game.ItemEquipmentStats;
+import net.runelite.client.game.ItemStats;
 import org.apache.commons.lang3.ArrayUtils;
 import net.runelite.api.Player;
 
@@ -695,14 +695,14 @@ public class PvpDamageCalc
 	// and count as 0 stats, but that should be very rare.
 	public static int[] getItemStats(int itemId)
 	{
-		ItemStats itemStats = PLUGIN.getItemManager().getItemStats(itemId, false);
+		ItemStats itemStats = PLUGIN.getItemManager().getItemStats(itemId);
 		if (itemStats == null)
 		{
 			EquipmentData itemData = EquipmentData.fromId(itemId);
 			if (itemData != null)
 			{
 				itemId = itemData.getItemId();
-				itemStats = PLUGIN.getItemManager().getItemStats(itemId, false);
+				itemStats = PLUGIN.getItemManager().getItemStats(itemId);
 			}
 		}
 
@@ -722,7 +722,7 @@ public class PvpDamageCalc
 				equipmentStats.getDrange(),	// 9
 				equipmentStats.getStr(),	// 10
 				equipmentStats.getRstr(),	// 11
-				equipmentStats.getMdmg(),	// 12
+				(int)equipmentStats.getMdmg(),	// 12
 			};
 		}
 

--- a/src/main/java/matsyir/pvpperformancetracker/views/FightLogDetailFrame.java
+++ b/src/main/java/matsyir/pvpperformancetracker/views/FightLogDetailFrame.java
@@ -51,7 +51,7 @@ import matsyir.pvpperformancetracker.models.RangeAmmoData;
 import net.runelite.api.Skill;
 import net.runelite.api.SpriteID;
 import net.runelite.api.kit.KitType;
-import net.runelite.http.api.item.ItemEquipmentStats;
+import net.runelite.client.game.ItemEquipmentStats;
 
 @Slf4j
 class FightLogDetailFrame extends JFrame
@@ -431,7 +431,7 @@ class FightLogDetailFrame extends JFrame
 			"<br/><strong>Other bonuses</strong>" + sep +
 			"Melee strength: " + prependPlusIfPositive(stats.getStr()) + sep +
 			"Ranged strength: " + prependPlusIfPositive(stats.getRstr() + ammoRangeStr) + sep +
-			"Magic damage: " + prependPlusIfPositive(stats.getMdmg()) + "%" + sep +
+			"Magic damage: " + prependPlusIfPositive((int)stats.getMdmg()) + "%" + sep +
 			"</html>";
 	}
 


### PR DESCRIPTION
This should fix the most recent build issue.

You may be interested in updating further to allow the float `mdmg` value, as that has been updated to allow the seers ring magic damage bonuses of `0.2` and `0.5`