### PR TITLE
fix: support alternative death animations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'matsyir.pvpperformancetracker'
-version = '1.5.10'
+version = '1.5.11'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
@@ -32,6 +32,7 @@ import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Objects;
 import lombok.Getter;
@@ -53,6 +54,11 @@ import org.apache.commons.lang3.StringUtils;
 @Getter
 public class FightPerformance implements Comparable<FightPerformance>
 {
+	private static final int[] DEATH_ANIMATIONS = {
+		AnimationID.DEATH,	// Default
+		10629,	// League IV
+		11902,	// League V
+	};
 	// Delay to assume a fight is over. May seem long, but sometimes people barrage &
 	// stand under for a while to eat. Fights will automatically end when either competitor dies.
 	private static final Duration NEW_FIGHT_DELAY = Duration.ofSeconds(21);
@@ -292,12 +298,12 @@ public class FightPerformance implements Comparable<FightPerformance>
 	{
 		boolean isOver = false;
 		// if either competitor died, end the fight.
-		if (opponent.getPlayer().getAnimation() == AnimationID.DEATH)
+		if (Arrays.stream(DEATH_ANIMATIONS).anyMatch(e -> e == opponent.getPlayer().getAnimation()))
 		{
 			opponent.died();
 			isOver = true;
 		}
-		if (competitor.getPlayer().getAnimation() == AnimationID.DEATH)
+		if (Arrays.stream(DEATH_ANIMATIONS).anyMatch(e -> e == competitor.getPlayer().getAnimation()))
 		{
 			competitor.died();
 			isOver = true;


### PR DESCRIPTION
This PR aims to fix the issue of alternative death animations not being tracked by the plugin, and thus not concluding a fight by attributing death to a player.

The proposed approach is very rudimentary. I figured this would be the simplest way to go about it instead of refactoring `AnimationData` to also support non-combat animations/spotanims. Which was something I was considering, since it'd give room to also implement tracking of augmenting spells which indirectly affect combat — primarily thinking about Arceuus spellbook (however, that may be its own PR if I get around to it).

I hope this fix is acceptable, else please let me know if there is another preferred solution.

Fixes #45 