### PR TITLE
feat: More robust HP estimation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ build
 .classpath
 nbactions.xml
 nb-configuration.xml
-nbproject/
+nbproject/bin/

--- a/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
@@ -120,11 +120,15 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 
 	@Getter
 	@Setter
-	private transient Integer estimatedHpBeforeHit = null; // Estimated opponent HP before this hit landed
+	@Expose
+	@SerializedName("eH") // Estimated Hp before hit
+	private Integer estimatedHpBeforeHit = null;
 
 	@Getter
 	@Setter
-	private transient Integer opponentMaxHp = null; // Max HP used for this entry's calculation
+	@Expose
+	@SerializedName("oH") // Opponent max Hp used for calc
+	private Integer opponentMaxHp = null;
 
 
 	// defender data

--- a/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
@@ -118,6 +118,14 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 	@Setter
 	private transient boolean koChanceCalculated = false; // Flag to track if KO chance was processed for this entry
 
+	@Getter
+	@Setter
+	private transient Integer estimatedHpBeforeHit = null; // Estimated opponent HP before this hit landed
+
+	@Getter
+	@Setter
+	private transient Integer opponentMaxHp = null; // Max HP used for this entry's calculation
+
 
 	// defender data
 	@Expose

--- a/src/main/java/matsyir/pvpperformancetracker/views/FightLogFrame.java
+++ b/src/main/java/matsyir/pvpperformancetracker/views/FightLogFrame.java
@@ -91,11 +91,11 @@ public class FightLogFrame extends JFrame
 		}
 
 		setIconImage(PLUGIN_ICON);
-		setSize(820, 503); // Increased width slightly for new column
+		setSize(860, 503); // Reverted width increase, removed debug columns
 		setLocation(rootPane.getLocationOnScreen());
 
 		JPanel mainPanel = new JPanel(new BorderLayout(4, 4));
-		Object[][] stats = new Object[fightLogEntries.size()][12]; // Increased column count
+		Object[][] stats = new Object[fightLogEntries.size()][13]; // Reverted column count
 		int i = 0;
 		int initialTick = 0;
 
@@ -117,24 +117,29 @@ public class FightLogFrame extends JFrame
 			stats[i][3] = nf.format(fightEntry.getAccuracy() * 100) + '%';
 			stats[i][4] = nf.format(fightEntry.getDeservedDamage());
 
-			// KO Chance column (Index 5)
+			// HP column (Index 5) - Display as Current/Max
+			Integer hp = fightEntry.getEstimatedHpBeforeHit();
+			Integer maxHp = fightEntry.getOpponentMaxHp();
+			stats[i][5] = (hp != null && maxHp != null) ? hp + "/" + maxHp : (hp != null ? String.valueOf(hp) : "-");
+
+			// KO Chance column (Index 6)
 			Double koChance = fightEntry.getKoChance();
-			stats[i][5] = koChance != null ? nfPercent.format(koChance) : "-";
+			stats[i][6] = koChance != null ? nfPercent.format(koChance) : "-";
 
 			// Shifted original columns
-			stats[i][6] = fightEntry.getAnimationData().isSpecial ? "✔" : "";
-			stats[i][7] = fightEntry.success() ? "✔" : "";
+			stats[i][7] = fightEntry.getAnimationData().isSpecial ? "✔" : "";
+			stats[i][8] = fightEntry.success() ? "✔" : "";
 
 			int prayIcon = PLUGIN.getSpriteForHeadIcon(fightEntry.getDefenderOverhead());
 			if (prayIcon > 0)
 			{
 				JLabel prayIconLabel = new JLabel();
 				PLUGIN.addSpriteToLabelIfValid(prayIconLabel, prayIcon, this::repaint);
-				stats[i][8] = prayIconLabel;
+				stats[i][9] = prayIconLabel;
 			}
 			else
 			{
-				stats[i][8] = "";
+				stats[i][9] = "";
 			}
 
 			if (fightEntry.getAnimationData().attackStyle == AnimationData.AttackStyle.MAGIC)
@@ -142,11 +147,11 @@ public class FightLogFrame extends JFrame
 				int freezeIcon = fightEntry.isSplash() ? SpriteID.SPELL_ICE_BARRAGE_DISABLED : SpriteID.SPELL_ICE_BARRAGE;
 				JLabel freezeIconLabel = new JLabel();
 				PLUGIN.addSpriteToLabelIfValid(freezeIconLabel, freezeIcon, this::repaint);
-				stats[i][9] = freezeIconLabel;
+				stats[i][10] = freezeIconLabel;
 			}
 			else
 			{
-				stats[i][9] = "";
+				stats[i][10] = "";
 			}
 
 			// offensive pray shown as icon or blank if none(0)
@@ -154,11 +159,11 @@ public class FightLogFrame extends JFrame
 			if (fightEntry.getAttackerOffensivePray() > 0)
 			{
 				PLUGIN.addSpriteToLabelIfValid(attackerOffensivePrayLabel, fightEntry.getAttackerOffensivePray(), this::repaint);
-				stats[i][10] = attackerOffensivePrayLabel;
+				stats[i][11] = attackerOffensivePrayLabel;
 			}
 			else
 			{
-				stats[i][10] = "";
+				stats[i][11] = "";
 			}
 
 			int tickDuration = fightEntry.getTick() - initialTick;
@@ -168,21 +173,21 @@ public class FightLogFrame extends JFrame
 				duration.toMinutes(),
 				duration.getSeconds() % 60,
 				durationMillis % 1000 / 100) + " (" + tickDuration + ")";
-			stats[i][11] = time;
+			stats[i][12] = time;
 
 			i++;
 		}
 
-		String[] header = { "Attacker", "Style", "Hit Range", "Accuracy", "Avg Hit", "KO Chance", "Special?", "Off-Pray?",
-				"Def Prayer", "Splash", "Offensive Pray", "Time, (Tick)" }; // Added KO Chance header
+		String[] header = { "Attacker", "Style", "Hit Range", "Accuracy", "Avg Hit", "HP", "KO Chance", "Special?", "Off-Pray?",
+				"Def Prayer", "Splash", "Offensive Pray", "Time, (Tick)" }; // Removed debug headers
 		table = new JTable(stats, header);
 		table.setRowHeight(30);
 		table.setDefaultEditor(Object.class, null);
 
 		table.getColumnModel().getColumn(1).setCellRenderer(new BufferedImageCellRenderer()); // Style
-		table.getColumnModel().getColumn(8).setCellRenderer(new BufferedImageCellRenderer()); // Def Prayer
-		table.getColumnModel().getColumn(9).setCellRenderer(new BufferedImageCellRenderer()); // Splash
-		table.getColumnModel().getColumn(10).setCellRenderer(new BufferedImageCellRenderer()); // Offensive Pray
+		table.getColumnModel().getColumn(9).setCellRenderer(new BufferedImageCellRenderer()); // Def Prayer
+		table.getColumnModel().getColumn(10).setCellRenderer(new BufferedImageCellRenderer()); // Splash
+		table.getColumnModel().getColumn(11).setCellRenderer(new BufferedImageCellRenderer()); // Offensive Pray
 
 		onRowSelected = e -> {
 			int row = table.getSelectedRow();


### PR DESCRIPTION
This pull request refines the Knockout (KO) chance feature introduced in v1.6.0 by improving the accuracy of the opponent HP estimation, particularly for ticks involving multiple hitsplats, and adds an HP column to the detailed fight log for better context. Previously any attacks with multiple hitsplats (dragon claws, dds) as well as other sources of damage such as vengeance would lead to inaccurate HP estimations.

**Changes:**

1.  **Improved HP Estimation (`PvpPerformanceTrackerPlugin.java`):**
    *   Implemented hitsplat buffering: Hitsplats are now collected per tick and processed together in the subsequent `onGameTick`.
    *   Adopted the HP calculation logic from the core Opponent Information plugin to determine `hpAfterTick` more accurately using `healthRatio`, `healthScale`, and max HP. (Pkers already use this as a reference, so using their strategy makes more sense)
    *   Integrated Hiscores lookup (`HiscoreManager`) for player opponents to get their actual max HP level, falling back to the `opponentHitpointsLevel` config setting if the lookup fails.
    *   Calculates `hpBeforeTick` by adding the `totalDamageThisTick` (sum of all hitsplats buffered for that opponent in that tick) to the calculated `hpAfterTick`. This covers attacks with multiple hitsplats as well as other damage sources such as vengeance.
    *   This `hpBeforeTick` is now used for the KO chance calculation, providing a better estimate, especially when multiple hitsplats land in the same tick.

2.  **Fight Log Enhancements (`FightLogEntry.java`, `FightLogFrame.java`):**
    *   Added a transient `opponentMaxHp` field to `FightLogEntry` to store the max HP value (from Hiscores or config) used for the HP/KO chance calculation for that specific entry.
    *   Added a transient `estimatedHpBeforeHit` field to `FightLogEntry` to store the calculated HP before the hit.
    *   Modified the "HP" column in the detailed fight log (`FightLogFrame`) to display the estimated HP in a "Current/Max" format (e.g., "85/99") using the `estimatedHpBeforeHit` and `opponentMaxHp` values. Displays "-" if estimation failed for that tick.

This approach covers all the edge cases I have noticed, and should prevent any additional config from complicating the user experience. Therefore it has my preference over switching to actual hp for the local player, although that is still a possibility.

I look forward to your thoughts! 😄 