### PR TITLE
Implement Hits on Robes statistic (#51)

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
@@ -35,6 +35,17 @@ import net.runelite.client.config.Range;
 @ConfigGroup("pvpperformancetracker")
 public interface PvpPerformanceTrackerConfig extends Config
 {
+	/**
+	 * Filter for hits on robes statistic.
+	 */
+	enum RobeHitFilter
+	{
+		BOTTOM,
+		TOP,
+		BOTH,
+		EITHER
+	}
+
 	int LEVEL_MIN = 1;
 	int LEVEL_MAX = 120;
 
@@ -118,6 +129,17 @@ public interface PvpPerformanceTrackerConfig extends Config
 	default boolean showFightHistoryPanel()
 	{
 		return true;
+	}
+
+	@ConfigItem(
+		keyName = "robeHitFilter",
+		name = "Hits on Robes Filter",
+		description = "Which part of the robe to count hits on: bottom, top, both, or either.",
+		position = 11
+	)
+	default RobeHitFilter robeHitFilter()
+	{
+		return RobeHitFilter.EITHER;
 	}
 
 	// ================================= Overlay =================================
@@ -243,10 +265,22 @@ public interface PvpPerformanceTrackerConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showOverlayRobeHits",
+		name = "Overlay: Show Hits on Robes",
+		description = "The overlay will display hits on robes ratio (melee & ranged attacks).<br>Max. of 5 lines on the overlay",
+		position = 107,
+		section = overlay
+	)
+	default boolean showOverlayRobeHits()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "showOverlayTotalKoChance",
 		name = "Overlay: Show Total KO Chance",
 		description = "The overlay will display total KO chances and sum percentage.<br>Max. of 5 lines on the overlay",
-		position = 107,
+		position = 108,
 		section = overlay
 	)
 	default boolean showOverlayTotalKoChance()
@@ -258,7 +292,7 @@ public interface PvpPerformanceTrackerConfig extends Config
 		keyName = "showOverlayLastKoChance",
 		name = "Overlay: Show Last KO Chance",
 		description = "The overlay will display the last KO chance percentage.<br>Max. of 5 lines on the overlay",
-		position = 108,
+		position = 109,
 		section = overlay
 	)
 	default boolean showOverlayLastKoChance()

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
@@ -59,8 +59,9 @@ import net.runelite.api.Player;
 public class PvpDamageCalc
 {
 	private static final int STAB_ATTACK = 0, SLASH_ATTACK = 1, CRUSH_ATTACK = 2, MAGIC_ATTACK = 3,
-		RANGE_ATTACK = 4, STAB_DEF = 5, SLASH_DEF = 6, CRUSH_DEF = 7, MAGIC_DEF = 8, RANGE_DEF = 9,
-		STRENGTH_BONUS = 10, RANGE_STRENGTH = 11, MAGIC_DAMAGE = 12;
+		RANGE_ATTACK = 4, STAB_DEF = 5, SLASH_DEF = 6, CRUSH_DEF = 7, MAGIC_DEF = 8;
+	public static final int RANGE_DEF = 9;
+	private static final int STRENGTH_BONUS = 10, RANGE_STRENGTH = 11, MAGIC_DAMAGE = 12;
 
 	private static final int STANCE_BONUS = 0; // assume they are not in controlled or defensive
 	private static final double UNSUCCESSFUL_PRAY_DMG_MODIFIER = 0.6; // modifier for when you unsuccessfully hit off-pray

--- a/src/main/java/matsyir/pvpperformancetracker/views/FightPerformancePanel.java
+++ b/src/main/java/matsyir/pvpperformancetracker/views/FightPerformancePanel.java
@@ -400,6 +400,36 @@ public class FightPerformancePanel extends JPanel
 		}
 		ghostBarragesLine.add(opponentGhostBarrages, BorderLayout.EAST);
 
+		// Hits on Robes line (count/total and percentage)
+		JPanel robeHitsLine = new JPanel(new BorderLayout());
+		robeHitsLine.setBackground(null);
+		// Competitor's hits on robes
+		int compHits = fight.getCompetitorRobeHits();
+		int compTotal = fight.getOpponent().getAttackCount() - fight.getOpponent().getTotalMagicAttackCount();
+		double compRatio = compTotal > 0 ? (double) compHits / compTotal : 0.0;
+		JLabel playerRobeHitsLabel = new JLabel(compHits + "/" + compTotal + " (" + nfPercent.format(compRatio) + ")");
+		playerRobeHitsLabel.setToolTipText(fight.getCompetitor().getName() + " hit on robes: " + compHits + "/" + compTotal + " (" + nfPercent.format(compRatio) + ")");
+		playerRobeHitsLabel.setForeground(compRatio < ((double)(fight.getOpponentRobeHits()) / Math.max(1, fight.getCompetitor().getAttackCount() - fight.getCompetitor().getTotalMagicAttackCount())) ? Color.GREEN : Color.WHITE);
+		robeHitsLine.add(playerRobeHitsLabel, BorderLayout.WEST);
+		// Opponent's hits on robes
+		int oppHits = fight.getOpponentRobeHits();
+		int oppTotal = fight.getCompetitor().getAttackCount() - fight.getCompetitor().getTotalMagicAttackCount();
+		double oppRatio = oppTotal > 0 ? (double) oppHits / oppTotal : 0.0;
+		JLabel opponentRobeHitsLabel = new JLabel(oppHits + "/" + oppTotal + " (" + nfPercent.format(oppRatio) + ")");
+		opponentRobeHitsLabel.setToolTipText(fight.getOpponent().getName() + " hit on robes: " + oppHits + "/" + oppTotal + " (" + nfPercent.format(oppRatio) + ")");
+		opponentRobeHitsLabel.setForeground(oppRatio < compRatio ? Color.GREEN : Color.WHITE);
+		robeHitsLine.add(opponentRobeHitsLabel, BorderLayout.EAST);
+
+		fightPanel.add(playerNamesLine);
+		fightPanel.add(offPrayStatsLine);
+		fightPanel.add(deservedDpsStatsLine);
+		fightPanel.add(dmgDealtStatsLine);
+		fightPanel.add(magicHitStatsLine);
+		fightPanel.add(offensivePrayStatsLine);
+		fightPanel.add(hpHealedLine);
+		fightPanel.add(ghostBarragesLine);
+		fightPanel.add(robeHitsLine);
+
 		// NINTH LINE: Total KO Chances
 		JPanel totalKoChanceLine = new JPanel();
 		totalKoChanceLine.setLayout(new BorderLayout());
@@ -444,16 +474,7 @@ public class FightPerformancePanel extends JPanel
 		opponentTotalKoChance.setForeground(Color.WHITE);
 		totalKoChanceLine.add(opponentTotalKoChance, BorderLayout.EAST);
 
-
-		fightPanel.add(playerNamesLine);
-		fightPanel.add(offPrayStatsLine);
-		fightPanel.add(deservedDpsStatsLine);
-		fightPanel.add(dmgDealtStatsLine);
-		fightPanel.add(magicHitStatsLine);
-		fightPanel.add(offensivePrayStatsLine);
-		fightPanel.add(hpHealedLine);
-		fightPanel.add(ghostBarragesLine);
-		fightPanel.add(totalKoChanceLine); // Add the new line
+		fightPanel.add(totalKoChanceLine);
 
 		add(fightPanel, BorderLayout.NORTH);
 


### PR DESCRIPTION
Closes https://github.com/Matsyir/pvp-performance-tracker/issues/51

## Overview

This PR implements the **Hits on Robes** statistic, configurable to count hits on robe bottom, top, both or either (default: `EITHER`). So far I've not made any specific adjustments for whether players are pure/zerk/main, I think it should be alright as is, but maybe you'd like to add something specific for this. The new stat is displayed:

- In each fight summary panel (beneath the ghost-barrage line)  
- In the averages panel (`TotalStatsPanel`)  
- In the live overlay (off by default; toggleable via config)  

## Changes

### Configuration  
- **`PvpPerformanceTrackerConfig`**  
  - Added `RobeHitFilter` enum (`BOTTOM`, `TOP`, `BOTH`, `EITHER`)  
  - Added `robeHitFilter` setting  
  - Added `showOverlayRobeHits` toggle  

### Core Logic  
- **`PvpDamageCalc`**  
  - Made `RANGE_DEF` public for robe detection  
- **`FightPerformance`**  
  - Added `competitorRobeHits` / `opponentRobeHits` fields  
  - Implemented `calculateRobeHits(PvpPerformanceTrackerConfig.RobeHitFilter)`  
  - Added getters: `getCompetitorRobeHits()`, `getOpponentRobeHits()`  
- **`PvpPerformanceTrackerPlugin`**  
  - Invoke `calculateRobeHits(...)` for new fights and during history import  

### UI Updates  
- **`FightPerformancePanel`**  
  - Inserted “Hits on Robes” row under the ghost-barrage line (for both competitor and opponent)  
- **`TotalStatsPanel`**  
  - Added average hits-on-robes display  
- **`PvpPerformanceTrackerOverlay`**  
  - Added optional overlay line for live hits on robes (hidden by default) 