### PR TITLE
fix: Start tracking PVP fights when player gets attacked

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -375,7 +375,7 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 
 		stopFightIfOver();
 
-		// if the client player already has a valid opponent,
+		// if the client player already has a valid opponent AND the fight has started,
 		// or the event source/target aren't players, skip any processing.
 		if ((hasOpponent() && currentFight.fightStarted())
 			|| !(event.getSource() instanceof Player)

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
@@ -336,11 +336,14 @@ public class FightPerformance implements Comparable<FightPerformance>
 		return combinedList;
 	}
 
-	// only count the fight as started if the competitor attacked, not the enemy because
-	// the person the competitor clicked on might be attacking someone else
+	// Count the fight as started if either:
+	// 1. The competitor has attacked the opponent
+	// 2. The opponent has attacked the competitor
+	// Attacks are only counted when there is a confirmed interaction between the two players
+	// Checking both makes sure that the very first interaction is counted/tracked
 	public boolean fightStarted()
 	{
-		return competitor.getAttackCount() > 0;
+		return competitor.getAttackCount() > 0 || opponent.getAttackCount() > 0;
 	}
 
 	// returns true if competitor off-pray hit success rate > opponent success rate.


### PR DESCRIPTION
## Bug Fix: Start tracking of PVP fights when player gets attacked

### Issue
Currently, the plugin only starts tracking fight data when the player attacks someone else. This misses valuable data when the player is attacked first, as those initial attacks aren't captured in the fight statistics.

### Fix
Modified the `fightStarted()` method to check both:
- If the player has attacked the opponent AND/OR
- If the opponent has attacked the player

This ensures all combat interactions are properly tracked from the very beginning of a fight, regardless of who initiated combat.

### Safety
This change is safe because attacks are only counted when there is a confirmed interaction between the two players. The verification logic in `checkForAttackAnimations()` ensures we're only tracking legitimate PVP encounters.