### PR TITLE
Ko performance improvement

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerOverlay.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerOverlay.java
@@ -179,53 +179,17 @@ public class PvpPerformanceTrackerOverlay extends Overlay
 		}
 
 		// --- KO Chance Calculation START ---
-		int competitorKoChances = 0;
-		Double lastCompetitorKoChance = null;
-		double competitorSurvivalProb = 1.0; // Start with 100% survival chance
-
-		int opponentKoChances = 0;
-		Double lastOpponentKoChance = null;
-		double opponentSurvivalProb = 1.0; // Start with 100% survival chance
-
-		String competitorName = fight.getCompetitor().getName();
-
-		ArrayList<FightLogEntry> logs = fight.getAllFightLogEntries();
-		for (FightLogEntry log : logs)
-		{
-			// Use the display KO chance calculated in post-processing
-			Double koChance = log.getDisplayKoChance();
-			if (koChance != null)
-			{
-				if (log.attackerName.equals(competitorName))
-				{
-					competitorKoChances++;
-					competitorSurvivalProb *= (1.0 - koChance); // Multiply by chance of *not* KOing
-					lastCompetitorKoChance = koChance;
-				}
-				else // Opponent's attack
-				{
-					opponentKoChances++;
-					opponentSurvivalProb *= (1.0 - koChance); // Multiply by chance of *not* KOing
-					lastOpponentKoChance = koChance;
-				}
-			}
-		}
-
-		// Calculate overall KO probability (1 - overall survival probability)
-		Double competitorOverallKoProb = (competitorKoChances > 0) ? (1.0 - competitorSurvivalProb) : null;
-		Double opponentOverallKoProb = (opponentKoChances > 0) ? (1.0 - opponentSurvivalProb) : null;
-
 		// Format Total KO Chance Line (Using Overall Probability)
-		String totalCompStr = competitorKoChances
-				+ (competitorOverallKoProb != null ? " (" + nfPercent.format(competitorOverallKoProb) + ")" : "");
-		String totalOppStr = opponentKoChances
-				+ (opponentOverallKoProb != null ? " (" + nfPercent.format(opponentOverallKoProb) + ")" : "");
+		String totalCompStr = fight.getCompetitorKoChanceCount()
+				+ (fight.getCompetitorTotalKoChance() > 0 ? " (" + nfPercent.format(fight.getCompetitorTotalKoChance()) + ")" : "");
+		String totalOppStr = fight.getOpponentKoChanceCount()
+				+ (fight.getOpponentTotalKoChance() > 0 ? " (" + nfPercent.format(fight.getOpponentTotalKoChance()) + ")" : "");
 		ovlTotalKoChanceLine.setLeft(totalCompStr);
 		ovlTotalKoChanceLine.setRight(totalOppStr);
 
 		// Format Last KO Chance Line
-		String lastCompStr = (lastCompetitorKoChance != null ? nfPercent.format(lastCompetitorKoChance) : "-");
-		String lastOppStr = (lastOpponentKoChance != null ? nfPercent.format(lastOpponentKoChance) : "-");
+		String lastCompStr = (fight.getCompetitorLastKoChance() != null ? nfPercent.format(fight.getCompetitorLastKoChance()) : "-");
+		String lastOppStr = (fight.getOpponentLastKoChance() != null ? nfPercent.format(fight.getOpponentLastKoChance()) : "-");
 		ovlLastKoChanceLine.setLeft(lastCompStr);
 		ovlLastKoChanceLine.setRight(lastOppStr);
 		// --- KO Chance Calculation END ---

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerOverlay.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerOverlay.java
@@ -48,7 +48,8 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
 public class PvpPerformanceTrackerOverlay extends Overlay
 {
 	private static final NumberFormat nfPercent = NumberFormat.getPercentInstance(); // For KO Chance %
-	static {
+	static
+	{
 		nfPercent.setMaximumFractionDigits(1);
 		nfPercent.setRoundingMode(RoundingMode.HALF_UP);
 	}
@@ -162,7 +163,8 @@ public class PvpPerformanceTrackerOverlay extends Overlay
 		ovlHpHealedLine.setLeft(String.valueOf(fight.getCompetitor().getHpHealed()));
 
 		// Update Hits on Robes overlay line
-		if (config.showOverlayRobeHits()) {
+		if (config.showOverlayRobeHits())
+		{
 			int compHits = fight.getCompetitorRobeHits();
 			int compTotal = fight.getOpponent().getAttackCount() - fight.getOpponent().getTotalMagicAttackCount();
 			double compRatio = compTotal > 0 ? (double) compHits / compTotal : 0.0;

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -1022,6 +1022,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 						entry.setDisplayKoChance(koChanceCurrent);
 						entry.setKoChance(koChanceCurrent);
 
+						currentFight.updateKoChanceStats(entry);
+
 						entry.setPartOfTickGroup(isGroup);
 
 						// Update HP for the next iteration

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
@@ -98,6 +98,16 @@ public class FightPerformance implements Comparable<FightPerformance>
 	@SerializedName("rhO") // robe hits on opponent
 	private int opponentRobeHits = 0;
 
+	// KO Chance stats, updated per-attack. Not serialized.
+	private transient double competitorTotalKoChance = 0;
+	private transient double opponentTotalKoChance = 0;
+	private transient Double competitorLastKoChance = null;
+	private transient Double opponentLastKoChance = null;
+	private transient int competitorKoChanceCount = 0;
+	private transient int opponentKoChanceCount = 0;
+	private transient double competitorSurvivalProb = 1.0;
+	private transient double opponentSurvivalProb = 1.0;
+
 	// shouldn't be used, just here so we can make a subclass, weird java thing
 	public FightPerformance()
 	{
@@ -557,5 +567,57 @@ public class FightPerformance implements Comparable<FightPerformance>
 	public int getOpponentRobeHits()
 	{
 		return opponentRobeHits;
+	}
+
+	public void updateKoChanceStats(FightLogEntry entry)
+	{
+		if (entry.getDisplayKoChance() == null) { return; }
+
+		double koChance = entry.getDisplayKoChance();
+
+		if (entry.getAttackerName().equals(competitor.getName()))
+		{
+			competitorKoChanceCount++;
+			competitorLastKoChance = koChance;
+			competitorSurvivalProb *= (1.0 - koChance);
+			competitorTotalKoChance = 1.0 - competitorSurvivalProb;
+		}
+		else
+		{
+			opponentKoChanceCount++;
+			opponentLastKoChance = koChance;
+			opponentSurvivalProb *= (1.0 - koChance);
+			opponentTotalKoChance = 1.0 - opponentSurvivalProb;
+		}
+	}
+
+	public double getCompetitorTotalKoChance()
+	{
+		return competitorTotalKoChance;
+	}
+
+	public double getOpponentTotalKoChance()
+	{
+		return opponentTotalKoChance;
+	}
+
+	public Double getCompetitorLastKoChance()
+	{
+		return competitorLastKoChance;
+	}
+
+	public Double getOpponentLastKoChance()
+	{
+		return opponentLastKoChance;
+	}
+
+	public int getCompetitorKoChanceCount()
+	{
+		return competitorKoChanceCount;
+	}
+
+	public int getOpponentKoChanceCount()
+	{
+		return opponentKoChanceCount;
 	}
 }


### PR DESCRIPTION
Moved the ko chance calculations from render() to onGameTick() for much better efficiency. Since it is called in the (!processedEntriesThisTick.isEmpty()) condition, the calculations are not done every tick, but only in the ticks that have entry-matched hitsplats.