### PR TITLE
HP polling simplification to support recent game revision update

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/models/HitsplatInfo.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/HitsplatInfo.java
@@ -12,21 +12,21 @@ public class HitsplatInfo
 	@Getter
 	private final HitsplatApplied event;
 
-	// Use volatile as these will be updated by a scheduled executor thread
+	// health ratio/scale at the time of the hitsplat
 	@Getter
-	private volatile int polledHealthRatio = -1;
+	private int healthRatio = -1;
 	@Getter
-	private volatile int polledHealthScale = -1;
+	private int healthScale = -1;
 
 	public HitsplatInfo(HitsplatApplied event)
 	{
 		this.event = event;
 	}
 
-	// Called by the delayed task to store the polled HP state
-	public void setPolledHp(int ratio, int scale)
+	// Called to store the HP state
+	public void setHp(int ratio, int scale)
 	{
-		this.polledHealthRatio = ratio;
-		this.polledHealthScale = scale;
+		this.healthRatio = ratio;
+		this.healthScale = scale;
 	}
 } 

--- a/src/main/java/matsyir/pvpperformancetracker/views/FightLogFrame.java
+++ b/src/main/java/matsyir/pvpperformancetracker/views/FightLogFrame.java
@@ -134,7 +134,7 @@ public class FightLogFrame extends JFrame
 			}
 			stats[i][5] = dmgLabel;
 			// HP column (Index 6) - Display as Current/Max
-			Integer hp = fightEntry.getEstimatedHpBeforeHit();
+			Integer hp = fightEntry.getDisplayHpBefore();
 			Integer maxHp = fightEntry.getOpponentMaxHp();
 			stats[i][6] = (hp != null && maxHp != null) ? hp + "/" + maxHp : (hp != null ? String.valueOf(hp) : "-");
 			// KO Chance column (Index 7)


### PR DESCRIPTION
Closes #57 as discussed. I got rid of the scheduled delay, since the HP is now updated by the game with each hitsplat. The forward cascade logic for regular hits that land in the same tick was still required. This is because such hitsplats are applied at the exact same time, so the HP of each will be the same. This is different to how a combination of a granite maul and a regular attack are applied, as they can be in the same tick, yet apart enough to have individual HP updates.