### PR TITLE
Custom dragon claws ko chance model

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -943,6 +943,33 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 								entry.setClawsHpBeforePhase2(hpBeforeThisCycle);
 							}
 						}
+						else if (entry.getAnimationData() == AnimationData.RANGED_DARK_BOW ||
+							entry.getAnimationData() == AnimationData.RANGED_DARK_BOW_SPEC)
+						{
+							int matchedAfter = entry.getMatchedHitsCount();
+							int matchedBefore = matchedAfter - matchedThisCycle;
+
+							if (matchedBefore == 0 && matchedThisCycle >= 2)
+							{
+								entry.setDarkBowHitsStacked(true);
+								if (entry.getDarkBowHpBeforeHit1() == null && hpBeforeThisCycle > 0)
+								{
+									entry.setDarkBowHpBeforeHit1(hpBeforeThisCycle);
+								}
+							}
+							else
+							{
+								if (matchedAfter >= 1 && entry.getDarkBowHpBeforeHit1() == null && hpBeforeThisCycle > 0)
+								{
+									entry.setDarkBowHpBeforeHit1(hpBeforeThisCycle);
+									entry.setDarkBowHpAfterHit1(hpBeforeThisCycle - damageThisCycle);
+								}
+								if (matchedAfter >= entry.getExpectedHits() && entry.getDarkBowHpBeforeHit2() == null && hpBeforeThisCycle > 0)
+								{
+									entry.setDarkBowHpBeforeHit2(hpBeforeThisCycle);
+								}
+							}
+						}
 					}
 				}
 
@@ -1032,6 +1059,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 
 						Double koChanceCurrent = null;
 						boolean isClawsSpec = entry.getAnimationData() == AnimationData.MELEE_DRAGON_CLAWS_SPEC && entry.getExpectedHits() >= 4;
+						boolean isDarkBow = entry.getAnimationData() == AnimationData.RANGED_DARK_BOW ||
+							entry.getAnimationData() == AnimationData.RANGED_DARK_BOW_SPEC;
 						if (isClawsSpec)
 						{
 							if (hpBeforeCurrent != null && entry.getMatchedHitsCount() >= entry.getExpectedHits())
@@ -1044,6 +1073,29 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 									healBetween = Math.max(0, hpBeforeP2 - hpAfterP1);
 								}
 								koChanceCurrent = PvpPerformanceTrackerUtils.calculateClawsTwoPhaseKo(entry.getAccuracy(), entry.getMaxHit(), hpBeforeCurrent, healBetween);
+							}
+						}
+						else if (isDarkBow)
+						{
+							if (hpBeforeCurrent != null && entry.getMatchedHitsCount() >= entry.getExpectedHits())
+							{
+								int healBetween = 0;
+								if (!entry.isDarkBowHitsStacked())
+								{
+									Integer hpAfterHit1 = entry.getDarkBowHpAfterHit1();
+									Integer hpBeforeHit2 = entry.getDarkBowHpBeforeHit2();
+									if (hpAfterHit1 != null && hpBeforeHit2 != null)
+									{
+										healBetween = Math.max(0, hpBeforeHit2 - hpAfterHit1);
+									}
+								}
+								koChanceCurrent = PvpPerformanceTrackerUtils.calculateDarkBowTwoPhaseKo(
+									entry.getAccuracy(),
+									entry.getMinHit(),
+									entry.getMaxHit(),
+									hpBeforeCurrent,
+									healBetween
+								);
 							}
 						}
 						else

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/Fighter.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/Fighter.java
@@ -267,6 +267,10 @@ class Fighter
 
 		FightLogEntry fightLogEntry = new FightLogEntry(player, opponent, pvpDamageCalc, offensivePray, levels, animationData);
 		fightLogEntry.setGmaulSpecial(isGmaulSpec);
+		if (animationData.isSpecial && animationData != AnimationData.MELEE_GRANITE_MAUL_SPEC)
+		{
+			PvpPerformanceTrackerPlugin.PLUGIN.recordNonGmaulSpecial(player.getName(), fightLogEntry.getTick());
+		}
 		if (PvpPerformanceTrackerPlugin.CONFIG.fightLogInChat())
 		{
 			PvpPerformanceTrackerPlugin.PLUGIN.sendTradeChatMessage(fightLogEntry.toChatMessage());

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
@@ -88,6 +88,7 @@ public class PvpDamageCalc
 	private static final int DBOW_DMG_MODIFIER = 2;
 	private static final int DBOW_SPEC_DMG_MODIFIER = 3;
 	private static final int DBOW_SPEC_MIN_HIT = 16;
+	private static final int DBOW_SPEC_MAX_HIT_PER_ARROW = 48;
 	private static final double DRAGON_CBOW_SPEC_DMG_MODIFIER = 1.2;
 
 	private static final double DDS_SPEC_ACCURACY_MODIFIER = 1.25;
@@ -526,6 +527,15 @@ public class PvpDamageCalc
 
 			maxHit *= dmgModifier;
 		}
+
+		if (dbow && usingSpec)
+		{
+			int cap = DBOW_SPEC_MAX_HIT_PER_ARROW * 2;
+			if (maxHit > cap)
+			{
+				maxHit = cap;
+			}
+		}
 	}
 
 	private void getMagicMaxHit(EquipmentData shield, int mageDamageBonus, AnimationData animationData, EquipmentData weapon, VoidStyle voidStyle, boolean successfulOffensive)
@@ -674,7 +684,12 @@ public class PvpDamageCalc
 		/**
 		 * Attacker Chance
 		 */
-		effectiveLevelPlayer = Math.floor(((attackerLevels.range * (successfulOffensive ? RIGOUR_OFFENSIVE_PRAYER_ATTACK_MODIFIER : 1)) + STANCE_BONUS) + 8);
+		int stanceBonus = STANCE_BONUS;
+		if (weapon == EquipmentData.DARK_BOW && usingSpec)
+		{
+			stanceBonus += 3; // dark bow spec is assumed to be on accurate
+		}
+		effectiveLevelPlayer = Math.floor(((attackerLevels.range * (successfulOffensive ? RIGOUR_OFFENSIVE_PRAYER_ATTACK_MODIFIER : 1)) + stanceBonus) + 8);
 		// apply void bonus if applicable
 		if (voidStyle == VoidStyle.VOID_ELITE_RANGE || voidStyle == VoidStyle.VOID_RANGE)
 		{

--- a/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
@@ -192,6 +192,52 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 	@Getter @Setter
 	private boolean isPartOfTickGroup = false;
 
+	// Transient fields for handling multi-tick Dragon Claws special attacks
+	private transient Integer clawsPhase1Damage = null;
+	private transient Integer clawsHpBeforePhase1 = null;
+	private transient Integer clawsHpAfterPhase1 = null;
+	private transient Integer clawsHpBeforePhase2 = null;
+
+	public Integer getClawsPhase1Damage()
+	{
+		return clawsPhase1Damage;
+	}
+
+	public void setClawsPhase1Damage(Integer clawsPhase1Damage)
+	{
+		this.clawsPhase1Damage = clawsPhase1Damage;
+	}
+
+	public Integer getClawsHpBeforePhase1()
+	{
+		return clawsHpBeforePhase1;
+	}
+
+	public void setClawsHpBeforePhase1(Integer clawsHpBeforePhase1)
+	{
+		this.clawsHpBeforePhase1 = clawsHpBeforePhase1;
+	}
+
+	public Integer getClawsHpAfterPhase1()
+	{
+		return clawsHpAfterPhase1;
+	}
+
+	public void setClawsHpAfterPhase1(Integer clawsHpAfterPhase1)
+	{
+		this.clawsHpAfterPhase1 = clawsHpAfterPhase1;
+	}
+
+	public Integer getClawsHpBeforePhase2()
+	{
+		return clawsHpBeforePhase2;
+	}
+
+	public void setClawsHpBeforePhase2(Integer clawsHpBeforePhase2)
+	{
+		this.clawsHpBeforePhase2 = clawsHpBeforePhase2;
+	}
+
 	public FightLogEntry(Player attacker, Player defender, PvpDamageCalc pvpDamageCalc, int attackerOffensivePray, CombatLevels levels, AnimationData animationData)
 	{
 		this.isFullEntry = true;

--- a/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
@@ -193,95 +193,31 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 	private boolean isPartOfTickGroup = false;
 
 	// Transient fields for handling multi-tick Dragon Claws special attacks
+	@Getter
+	@Setter
 	private transient Integer clawsPhase1Damage = null;
+	@Getter
+	@Setter
 	private transient Integer clawsHpBeforePhase1 = null;
+	@Getter
+	@Setter
 	private transient Integer clawsHpAfterPhase1 = null;
+	@Getter
+	@Setter
 	private transient Integer clawsHpBeforePhase2 = null;
 	// Transient fields for handling Dark Bow double-hit sequencing
+	@Getter
+	@Setter
 	private transient Integer darkBowHpBeforeHit1 = null;
+	@Getter
+	@Setter
 	private transient Integer darkBowHpAfterHit1 = null;
+	@Getter
+	@Setter
 	private transient Integer darkBowHpBeforeHit2 = null;
+	@Getter
+	@Setter
 	private transient boolean darkBowHitsStacked = false;
-
-	public Integer getClawsPhase1Damage()
-	{
-		return clawsPhase1Damage;
-	}
-
-	public void setClawsPhase1Damage(Integer clawsPhase1Damage)
-	{
-		this.clawsPhase1Damage = clawsPhase1Damage;
-	}
-
-	public Integer getClawsHpBeforePhase1()
-	{
-		return clawsHpBeforePhase1;
-	}
-
-	public void setClawsHpBeforePhase1(Integer clawsHpBeforePhase1)
-	{
-		this.clawsHpBeforePhase1 = clawsHpBeforePhase1;
-	}
-
-	public Integer getClawsHpAfterPhase1()
-	{
-		return clawsHpAfterPhase1;
-	}
-
-	public void setClawsHpAfterPhase1(Integer clawsHpAfterPhase1)
-	{
-		this.clawsHpAfterPhase1 = clawsHpAfterPhase1;
-	}
-
-	public Integer getClawsHpBeforePhase2()
-	{
-		return clawsHpBeforePhase2;
-	}
-
-	public void setClawsHpBeforePhase2(Integer clawsHpBeforePhase2)
-	{
-		this.clawsHpBeforePhase2 = clawsHpBeforePhase2;
-	}
-
-	public Integer getDarkBowHpBeforeHit1()
-	{
-		return darkBowHpBeforeHit1;
-	}
-
-	public void setDarkBowHpBeforeHit1(Integer darkBowHpBeforeHit1)
-	{
-		this.darkBowHpBeforeHit1 = darkBowHpBeforeHit1;
-	}
-
-	public Integer getDarkBowHpAfterHit1()
-	{
-		return darkBowHpAfterHit1;
-	}
-
-	public void setDarkBowHpAfterHit1(Integer darkBowHpAfterHit1)
-	{
-		this.darkBowHpAfterHit1 = darkBowHpAfterHit1;
-	}
-
-	public Integer getDarkBowHpBeforeHit2()
-	{
-		return darkBowHpBeforeHit2;
-	}
-
-	public void setDarkBowHpBeforeHit2(Integer darkBowHpBeforeHit2)
-	{
-		this.darkBowHpBeforeHit2 = darkBowHpBeforeHit2;
-	}
-
-	public boolean isDarkBowHitsStacked()
-	{
-		return darkBowHitsStacked;
-	}
-
-	public void setDarkBowHitsStacked(boolean darkBowHitsStacked)
-	{
-		this.darkBowHitsStacked = darkBowHitsStacked;
-	}
 
 	public FightLogEntry(Player attacker, Player defender, PvpDamageCalc pvpDamageCalc, int attackerOffensivePray, CombatLevels levels, AnimationData animationData)
 	{

--- a/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
@@ -197,6 +197,11 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 	private transient Integer clawsHpBeforePhase1 = null;
 	private transient Integer clawsHpAfterPhase1 = null;
 	private transient Integer clawsHpBeforePhase2 = null;
+	// Transient fields for handling Dark Bow double-hit sequencing
+	private transient Integer darkBowHpBeforeHit1 = null;
+	private transient Integer darkBowHpAfterHit1 = null;
+	private transient Integer darkBowHpBeforeHit2 = null;
+	private transient boolean darkBowHitsStacked = false;
 
 	public Integer getClawsPhase1Damage()
 	{
@@ -236,6 +241,46 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 	public void setClawsHpBeforePhase2(Integer clawsHpBeforePhase2)
 	{
 		this.clawsHpBeforePhase2 = clawsHpBeforePhase2;
+	}
+
+	public Integer getDarkBowHpBeforeHit1()
+	{
+		return darkBowHpBeforeHit1;
+	}
+
+	public void setDarkBowHpBeforeHit1(Integer darkBowHpBeforeHit1)
+	{
+		this.darkBowHpBeforeHit1 = darkBowHpBeforeHit1;
+	}
+
+	public Integer getDarkBowHpAfterHit1()
+	{
+		return darkBowHpAfterHit1;
+	}
+
+	public void setDarkBowHpAfterHit1(Integer darkBowHpAfterHit1)
+	{
+		this.darkBowHpAfterHit1 = darkBowHpAfterHit1;
+	}
+
+	public Integer getDarkBowHpBeforeHit2()
+	{
+		return darkBowHpBeforeHit2;
+	}
+
+	public void setDarkBowHpBeforeHit2(Integer darkBowHpBeforeHit2)
+	{
+		this.darkBowHpBeforeHit2 = darkBowHpBeforeHit2;
+	}
+
+	public boolean isDarkBowHitsStacked()
+	{
+		return darkBowHitsStacked;
+	}
+
+	public void setDarkBowHitsStacked(boolean darkBowHitsStacked)
+	{
+		this.darkBowHitsStacked = darkBowHitsStacked;
 	}
 
 	public FightLogEntry(Player attacker, Player defender, PvpDamageCalc pvpDamageCalc, int attackerOffensivePray, CombatLevels levels, AnimationData animationData)

--- a/src/main/java/matsyir/pvpperformancetracker/utils/PvpPerformanceTrackerUtils.java
+++ b/src/main/java/matsyir/pvpperformancetracker/utils/PvpPerformanceTrackerUtils.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 @Slf4j
 public class PvpPerformanceTrackerUtils
 {
+	private static final int DBOW_MAX_HIT_CAP = 48; // per-arrow cap with dragon arrows in PvP
+
 	/**
 	 * Calculates the chance of knocking out an opponent with a single hit.
 	 *
@@ -220,6 +222,125 @@ public class PvpPerformanceTrackerUtils
 			ko = 1.0;
 		}
 		return ko;
+	}
+
+	/**
+	 * Attempt-level KO probability for Dark Bow double hits, factoring any healing between hits.
+	 * Applies per-arrow damage caps by collapsing rolls above the cap into the capped value.
+	 */
+	public static Double calculateDarkBowTwoPhaseKo(double accuracy, int minHitTotal, int maxHitTotal, int hpBefore, int healBetween)
+	{
+		if (maxHitTotal <= 0 || hpBefore <= 0)
+		{
+			return null;
+		}
+
+		double acc = Math.max(0.0, Math.min(1.0, accuracy));
+		int perArrowMax = Math.max(0, maxHitTotal / 2);
+		if (perArrowMax <= 0)
+		{
+			return null;
+		}
+
+		int perArrowMin = Math.max(0, minHitTotal / 2);
+		double[] dist = buildCappedDamageDistribution(acc, perArrowMin, perArrowMax, DBOW_MAX_HIT_CAP);
+		if (dist == null || dist.length == 0)
+		{
+			return null;
+		}
+
+		int maxDamage = dist.length - 1;
+		double[] tail = new double[maxDamage + 2];
+		for (int dmg = maxDamage; dmg >= 0; dmg--)
+		{
+			tail[dmg] = tail[dmg + 1] + dist[dmg];
+		}
+
+		double ko = 0.0;
+		for (int d1 = 0; d1 <= maxDamage; d1++)
+		{
+			double p1 = dist[d1];
+			if (p1 <= 0.0)
+			{
+				continue;
+			}
+
+			if (d1 >= hpBefore)
+			{
+				ko += p1;
+				continue;
+			}
+
+			int hpNeeded = hpBefore - d1 + Math.max(0, healBetween);
+			if (hpNeeded <= 0)
+			{
+				ko += p1;
+				continue;
+			}
+
+			if (hpNeeded <= maxDamage)
+			{
+				ko += p1 * tail[hpNeeded];
+			}
+		}
+
+		if (ko < 0.0)
+		{
+			ko = 0.0;
+		}
+		else if (ko > 1.0)
+		{
+			ko = 1.0;
+		}
+		return ko;
+	}
+
+	private static double[] buildCappedDamageDistribution(double accuracy, int minHit, int maxHit, int maxHitCap)
+	{
+		if (maxHit < 0)
+		{
+			return null;
+		}
+
+		int effectiveCap = maxHitCap > 0 ? maxHitCap : maxHit;
+		int maxDamage = Math.min(maxHit, effectiveCap);
+		if (maxDamage < 0)
+		{
+			return null;
+		}
+
+		double[] dist = new double[maxDamage + 1];
+		double acc = Math.max(0.0, Math.min(1.0, accuracy));
+
+		if (acc <= 0.0)
+		{
+			dist[0] = 1.0;
+			return dist;
+		}
+
+		int clampedMin = Math.max(0, minHit);
+		clampedMin = Math.min(clampedMin, maxHit);
+		clampedMin = Math.min(clampedMin, effectiveCap);
+
+		int rollCount = maxHit + 1;
+		double hitProb = acc / rollCount;
+
+		for (int roll = 0; roll <= maxHit; roll++)
+		{
+			int dmg = roll < clampedMin ? clampedMin : roll;
+			if (dmg > effectiveCap)
+			{
+				dmg = effectiveCap;
+			}
+			if (dmg > maxDamage)
+			{
+				dmg = maxDamage;
+			}
+			dist[dmg] += hitProb;
+		}
+
+		dist[0] += 1.0 - acc;
+		return dist;
 	}
 
     public static int getSpriteForSkill(Skill skill)


### PR DESCRIPTION
This new model is a big improvement over the standard ko chance model, because the hitsplats from dragon claws land on two ticks, it now:
* Takes into account the different hitsplat patterns (which of the 4 accuracy rolls
lands).
* Takes into account any HP healed in between the two ticks of damage.
* Combines the chance of dying from the damage of each tick into a single ko chance.

Now also correctly matches hitsplats for the dragon claws - granite maul combo, for which the hitsplats tend to appear as 2x claws -> 1x maul -> 2x claws.