### PR TITLE
fix(rings): update dt2 ring item ids

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/models/RingData.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/RingData.java
@@ -39,10 +39,10 @@ public enum RingData
 	BERSERKER_RING_I("Berserker Ring (i)", ItemID.BERSERKER_RING_I),
 	RING_OF_SUFFERING_I("Ring of Suffering (i)", ItemID.RING_OF_SUFFERING_I),
 	BRIMSTONE_RING("Brimstone Ring", ItemID.BRIMSTONE_RING),
-	MAGUS_RING("Magus ring", ItemID.MAGUS_RING),
-	VENATOR_RING("Venator ring", ItemID.VENATOR_RING),
-	BELLATOR_RING("Bellator ring", ItemID.BELLATOR_RING),
-	ULTOR_RING("Ultor ring", ItemID.ULTOR_RING),
+	MAGUS_RING("Magus ring", ItemID.MAGUS_RING_28313),
+	VENATOR_RING("Venator ring", ItemID.VENATOR_RING_28310),
+	BELLATOR_RING("Bellator ring", ItemID.BELLATOR_RING_28316),
+	ULTOR_RING("Ultor ring", ItemID.ULTOR_RING_28307),
 	RING_OF_SHADOWS("Ring of Shadows", ItemID.RING_OF_SHADOWS),
 	NONE("None", -1);
 


### PR DESCRIPTION
For some reason ItemID.ULTOR_RING returns the id for some beta version which no longer exists with 0 stats. This is the case for all DT2 rings, so I've replaced them with their actual ID.

https://oldschool.runescape.wiki/w/Ultor_ring_(beta)