### PR TITLE
Feat req/pvp hub optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build
 nbactions.xml
 nb-configuration.xml
 nbproject/bin/
+bin/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ Massive thanks to [all other contributors](https://github.com/Matsyir/pvp-perfor
 
 ![Plugin Overview Image](https://i.imgur.com/LkQGda3.png)
 
--------------------------------
-I am happy to see other features/stats come into this plugin in the future, feel free to submit issues/suggestions & PRs. If you find a weapon that doesn't work, let me know as well.
+# PvP-Hub
 
-Note that I'm not very active on RS lately myself, so this project is not among my highest priorities - but I'm happy to keep supporting it, especially for issues that affect most users, with normal gear setups in places like LMS or PvP Arena. In other words, the plugin is sort of "on life support" when it comes to the work I'm putting into it, but glad to keep managing it if others want to contribute.
+Generously created & hosted by [LogicalSolutions](https://github.com/LogicalSoIutions), and introduced in 1.7.4, this
+new opt-in feature automatically uploads all of your fights to the PvP-Hub website, where it can be publicly viewed by
+anyone. This is disabled by default - the plugin remains entirely client-side if you do not manually opt-into this
+feature, and there will be a warning popup when you attempt to do so.
 
-# Why does this PvP-Hub setting say my IP is being requested?
+## Why does this PvP-Hub setting say my IP is being requested?
 
 To use this feature, the plugin needs to send some fight data to a server:
 
@@ -35,7 +37,18 @@ The website source code is available here:
 This feature is completely optional.
 
 - The setting is disabled by default.
-- If the checkbox is off, no data is sent to the server.
+- If the checkbox is disabled, no data is sent to the server. If it is enabled, data is only sent to the server when you
+  finish a fight. This data includes your fight data, RSN, and a uniquely generated fight ID.
 - If you enable it, and your opponent also has it enabled, the website can automatically use Advanced Analysis.
-- Advanced Analysis lets you view the full fight, including extra details such as ammo and ring used.
+- Advanced Analysis lets you view the full fight, including more accurate calculations, extra details such as ammo,
+  rings used, and more.
 - If your opponent does not have the plugin, or has this setting disabled, the plugin will use your existing gear settings instead.
+
+-------------------------------
+I am happy to see other features/stats come into this plugin in the future, feel free to submit issues/suggestions &
+PRs. If you find a weapon that doesn't work, let me know as well.
+
+Note that I'm not very active on RS lately myself, so this project is not among my highest priorities - but I'm happy to
+keep supporting it, especially for issues that affect most users, with normal gear setups in places like LMS or PvP
+Arena. In other words, the plugin is sort of "on life support" when it comes to the work I'm putting into it, but glad
+to keep managing it if others want to contribute.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,25 @@ Massive thanks to [all other contributors](https://github.com/Matsyir/pvp-perfor
 I am happy to see other features/stats come into this plugin in the future, feel free to submit issues/suggestions & PRs. If you find a weapon that doesn't work, let me know as well.
 
 Note that I'm not very active on RS lately myself, so this project is not among my highest priorities - but I'm happy to keep supporting it, especially for issues that affect most users, with normal gear setups in places like LMS or PvP Arena. In other words, the plugin is sort of "on life support" when it comes to the work I'm putting into it, but glad to keep managing it if others want to contribute.
+
+# Why does this PvP-Hub setting say my IP is being requested?
+
+To use this feature, the plugin needs to send some fight data to a server:
+
+https://osrs.pvp-hub.com
+
+Like any website or online service, that server is reached through an IP address. This is simply how devices communicate over the internet.
+
+When the plugin sends data to the server, the server can technically see the IP address the request came from. This is normal for any internet request. However, your IP address is not stored or logged. The server receives the request, processes it, and does not save your IP.
+
+The website source code is available here:
+
+[View the source code on GitHub](https://github.com/LogicalSoIutions/osrs-pvp-performance-tracker-website)
+
+This feature is completely optional.
+
+- The setting is disabled by default.
+- If the checkbox is off, no data is sent to the server.
+- If you enable it, and your opponent also has it enabled, the website can automatically use Advanced Analysis.
+- Advanced Analysis lets you view the full fight, including extra details such as ammo and ring used.
+- If your opponent does not have the plugin, or has this setting disabled, the plugin will use your existing gear settings instead.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PvP Performance Tracker (v1.7.3)
+# PvP Performance Tracker (v1.7.4)
 [![Active Installs](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/pvp-performance-tracker)](https://runelite.net/plugin-hub/Matsyir) [![Plugin Rank](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/pvp-performance-tracker)](https://runelite.net/plugin-hub)
 
 Tracks PvP performance by keeping track of various stats. Mostly useful for 1v1 PvP fights that involve overhead prayers and/or gear switching, Last Man Standing & PvP arena "NHing" being the perfect examples. Multi will cause problems. **Potentially inaccurate:** there are some imperfections and assumptions in this plugin, but it is generally accurate for most popular gear setups & spec weapons. 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'matsyir.pvpperformancetracker'
-version = '1.7.3'
+version = '1.7.4'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
@@ -136,6 +136,7 @@ public interface PvpPerformanceTrackerConfig extends Config
 		keyName = "uploadFightsToPvpHub",
 		name = "Upload Fights to PvP-Hub.com",
 		description = "When enabled, fights will be assigned a shared ID and uploaded to PvP-Hub.com after they end.",
+		warning = "This feature will submit your RSN, fight logs, and IP address to a 3rd-party server not controlled or verified by Runelite developers."
 		position = 1200
 	)
 	default boolean uploadFightsToPvpHub()

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
@@ -132,6 +132,17 @@ public interface PvpPerformanceTrackerConfig extends Config
 		return RobeHitFilter.EITHER;
 	}
 
+	@ConfigItem(
+		keyName = "uploadFightsToPvpHub",
+		name = "Upload Fights to PvP-Hub.com",
+		description = "When enabled, fights will be assigned a shared ID and uploaded to PvP-Hub.com after they end.",
+		position = 1200
+	)
+	default boolean uploadFightsToPvpHub()
+	{
+		return false;
+	}
+
 	// ================================= Overlay =================================
 
 	@ConfigItem(

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
@@ -546,14 +546,14 @@ public interface PvpPerformanceTrackerConfig extends Config
 
 	// ================================= On-update flags for chat message update summaries =================================
 	// to avoid spamming multiple update messages for a user who was inactive, just use and overwrite one at a time.
-	String updateMsgKey = "updateMsgShown1_7_2";
+	String updateMsgKey = "updateMsgShown1_7_4";
 	@ConfigItem(
 		keyName = updateMsgKey,
 		name = "Update Msg flag for most recent update",
 		description = "Tracks if the update chat message for the most recent update has been shown.",
 		hidden = true
 	)
-	default boolean updateMsgShown1_7_2()
+	default boolean updateMsgShown1_7_4()
 	{
 		return false;
 	}

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
@@ -136,7 +136,7 @@ public interface PvpPerformanceTrackerConfig extends Config
 		keyName = "uploadFightsToPvpHub",
 		name = "Upload Fights to PvP-Hub.com",
 		description = "When enabled, fights will be assigned a shared ID and uploaded to PvP-Hub.com after they end.",
-		warning = "This feature will submit your RSN, fight logs, and IP address to a 3rd-party server not controlled or verified by Runelite developers."
+		warning = "This feature will submit your RSN, fight logs, and IP address to a 3rd-party server not controlled or verified by Runelite developers.",
 		position = 1200
 	)
 	default boolean uploadFightsToPvpHub()

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -63,6 +63,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import matsyir.pvpperformancetracker.controllers.FightPerformance;
 import matsyir.pvpperformancetracker.controllers.Fighter;
+import matsyir.pvpperformancetracker.controllers.PvpHubUploader;
 import matsyir.pvpperformancetracker.models.AnimationData;
 import matsyir.pvpperformancetracker.models.CombatLevels;
 import matsyir.pvpperformancetracker.models.FightLogEntry;
@@ -110,6 +111,7 @@ import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.AsyncBufferedImage;
 import net.runelite.client.util.ImageUtil;
+import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.ArrayUtils;
 
 
@@ -123,7 +125,7 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 
 	// reminder: the version number update is needed in a few different places.
 	// Run a find-all of the old version number before updating version.
-	public static final String PLUGIN_VERSION = "1.7.3";
+	public static final String PLUGIN_VERSION = "1.7.4";
 	public static final String CONFIG_KEY = "pvpperformancetracker";
 	// Data folder naming history:
 	// "pvp-performance-tracker": From release, until 1.5.9 update @ 2024-08-19
@@ -210,6 +212,7 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 	private final Map<Integer, List<HitsplatInfo>> incomingHitsplatsBuffer = new ConcurrentHashMap<>(); // Stores hitsplats *received* by players per tick.
 	private final Map<String, Integer> lastNonGmaulSpecTickByAttacker = new ConcurrentHashMap<>();
 	private HiscoreEndpoint hiscoreEndpoint = HiscoreEndpoint.NORMAL; // Added field
+	private OkHttpClient httpClient;
 
 	// #################################################################################################################
 	// ##################################### Core RL plugin functions & RL Events ######################################
@@ -263,6 +266,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 		overlayManager.add(overlay);
 
 		spriteCache = new HashMap<>(); // prepare sprite cache
+		
+		httpClient = new OkHttpClient();
 
 		// prepare default N/A or None symbol for eventual use.
 		clientThread.invokeLater(() -> DEFAULT_NONE_SYMBOL = itemManager.getImage(20594));
@@ -1288,6 +1293,14 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 		// add fight to fight history if it actually started
 		if (currentFight.fightStarted())
 		{
+			// Upload to PvP-Hub if enabled and a fight ID was generated
+			if (CONFIG.uploadFightsToPvpHub() && currentFight.getFightId() != null
+					&& !currentFight.getFightId().isEmpty())
+			{
+				final FightPerformance fightToUpload = currentFight;
+				executor.submit(() -> PvpHubUploader.uploadFight(fightToUpload, GSON, httpClient));
+			}
+
 			addToFightHistory(currentFight);
 		}
 		currentFight = null;

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -1174,16 +1174,16 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 
 		chatMessageManager.queue(QueuedMessage.builder()
 			.type(ChatMessageType.GAMEMESSAGE)
-			.runeLiteFormattedMessage("PvP Performance Tracker 1.7.2 Update: " +
-				"Track ely damage reduction & SOTD spec melee damage reduction. " +
-				"Improved KO chance for dragon claws & dark bow special attacks. " +
-				"Scorching bow now uses dragon arrows. (+ 1.7.3 game data hotfix & LMS adjustments).")
+			.runeLiteFormattedMessage("PvP Performance Tracker 1.7.4 Update: New OPT-IN feature which automatically uploads " +
+				"your fight data to a PvP Hub website, where it can be publicly viewed by anyone. This is disabled by default - " +
+				"the plugin remains entirely client-side if you do not manually opt-into this feature.")
 				.build());
 		configManager.setConfiguration(CONFIG_KEY, config.updateMsgKey, true);
 
 		// remove any old unnecessary flags after updating
 		configManager.unsetConfiguration(CONFIG_KEY, "updateNoteMay72025Shown_v2");
 		configManager.unsetConfiguration(CONFIG_KEY, "updateMsgShown1_7_1");
+		configManager.unsetConfiguration(CONFIG_KEY, "updateMsgShown1_7_2");
 	}
 
 	private void update(String oldVersion)
@@ -1293,6 +1293,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 		// add fight to fight history if it actually started
 		if (currentFight.fightStarted())
 		{
+			addToFightHistory(currentFight);
+
 			// Upload to PvP-Hub if enabled and a fight ID was generated
 			if (CONFIG.uploadFightsToPvpHub() && currentFight.getFightId() != null
 					&& !currentFight.getFightId().isEmpty())
@@ -1300,8 +1302,6 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 				final FightPerformance fightToUpload = currentFight;
 				executor.submit(() -> PvpHubUploader.uploadFight(fightToUpload, GSON, httpClient));
 			}
-
-			addToFightHistory(currentFight);
 		}
 		currentFight = null;
 		hitsplatBuffer.clear();

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
@@ -43,6 +43,7 @@ import matsyir.pvpperformancetracker.models.AnimationData.AttackStyle;
 import matsyir.pvpperformancetracker.models.CombatLevels;
 import matsyir.pvpperformancetracker.models.FightLogEntry;
 import matsyir.pvpperformancetracker.models.FightType;
+import matsyir.pvpperformancetracker.utils.FightIdGenerator;
 import matsyir.pvpperformancetracker.models.oldVersions.FightPerformance__1_5_5;
 import net.runelite.api.AnimationID;
 import net.runelite.api.Player;
@@ -88,6 +89,13 @@ public class FightPerformance implements Comparable<FightPerformance>
 	@Expose
 	@SerializedName("w")
 	private int world;
+	@Expose
+	@SerializedName("fightID")
+	@Getter
+	private String fightId;
+
+	private transient boolean fightIdGenerated = false;
+	private transient long initialTime = 0;
 
 	private int competitorPrevHp; // intentionally don't serialize this, temp variable used to calculate hp healed.
 
@@ -130,6 +138,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 		// this is initialized soon before the NEW_FIGHT_DELAY time because the event we
 		// determine the opponent from is not fully reliable.
 		lastFightTime = Instant.now().minusSeconds(NEW_FIGHT_DELAY.getSeconds() - 5).toEpochMilli();
+		initialTime = Instant.now().toEpochMilli();
 
 		this.competitor = new Fighter(this, competitor);
 		this.opponent = new Fighter(this, opponent);
@@ -144,6 +153,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 		this.competitor = old.competitor;
 		this.opponent = old.opponent;
 		this.lastFightTime = old.lastFightTime;
+		this.initialTime = old.lastFightTime;
 		if (old.isLmsFight)
 		{
 			if (!competitor.getFightLogEntries().isEmpty())
@@ -214,6 +224,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 		}
 
 		lastFightTime = Instant.now().minusSeconds(secondOffset).toEpochMilli();
+		this.initialTime = lastFightTime;
 	}
 
 	// If the given playerName is in this fight, check the Fighter's current animation,
@@ -245,6 +256,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 					competitorLevels);
 				lastFightTime = Instant.now().toEpochMilli();
 				addedAttack = true;
+				maybeGenerateFightId();
 
 			}
 		}
@@ -260,6 +272,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 				// add a defensive log for the competitor while the opponent is attacking, to be used with the fight analysis/merge
 				competitor.addDefensiveLogs(competitorLevels, PLUGIN.currentlyUsedOffensivePray());
 				lastFightTime = Instant.now().toEpochMilli();
+				maybeGenerateFightId();
 			}
 		}
 
@@ -549,6 +562,33 @@ public class FightPerformance implements Comparable<FightPerformance>
 					opponent.addRobeHit();
 				}
 			}
+		}
+	}
+
+	/**
+	 * Generates the fight ID if it hasn't been generated yet and the upload config is enabled.
+	 * Uses both player names, world, and the current game tick as seed material.
+	 */
+	private void maybeGenerateFightId()
+	{
+		if (fightIdGenerated || !CONFIG.uploadFightsToPvpHub())
+		{
+			return;
+		}
+
+		if (competitor.getName() != null && opponent.getName() != null)
+		{
+			if (initialTime == 0)
+			{
+				initialTime = lastFightTime;
+			}
+			fightId = FightIdGenerator.generateFightId(
+				competitor.getName(),
+				opponent.getName(),
+				world,
+				initialTime
+			);
+			fightIdGenerated = true;
 		}
 	}
 

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
@@ -256,7 +256,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 					competitorLevels);
 				lastFightTime = Instant.now().toEpochMilli();
 				addedAttack = true;
-				maybeGenerateFightId();
+				ensureFightIdGenerated();
 
 			}
 		}
@@ -272,7 +272,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 				// add a defensive log for the competitor while the opponent is attacking, to be used with the fight analysis/merge
 				competitor.addDefensiveLogs(competitorLevels, PLUGIN.currentlyUsedOffensivePray());
 				lastFightTime = Instant.now().toEpochMilli();
-				maybeGenerateFightId();
+				ensureFightIdGenerated();
 			}
 		}
 
@@ -569,7 +569,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 	 * Generates the fight ID if it hasn't been generated yet and the upload config is enabled.
 	 * Uses both player names, world, and the current game tick as seed material.
 	 */
-	private void maybeGenerateFightId()
+	private void ensureFightIdGenerated()
 	{
 		if (fightIdGenerated || !CONFIG.uploadFightsToPvpHub())
 		{

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubUploader.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubUploader.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021, Matsyir <https://github.com/Matsyir>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package matsyir.pvpperformancetracker.controllers;
+
+import com.google.gson.Gson;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * Handles uploading fight data to PvP-Hub.com.
+ * Uploads are asynchronous and failures are silently logged.
+ */
+@Slf4j
+public class PvpHubUploader
+{
+	private static final String UPLOAD_URL = "https://osrs.pvp-hub.com/api/fights";
+	private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+	/**
+	 * Asynchronously uploads a completed fight to PvP-Hub.com.
+	 * Failures are logged but do not interrupt the user.
+	 *
+	 * @param fight      the completed fight performance data
+	 * @param gson       the Gson instance configured for serialization
+	 * @param httpClient the OkHttpClient to use for the request
+	 */
+	public static void uploadFight(FightPerformance fight, Gson gson, OkHttpClient httpClient)
+	{
+		if (fight == null || fight.getFightId() == null || fight.getFightId().isEmpty())
+		{
+			log.debug("Skipping PvP-Hub upload: fight or fightId is null/empty");
+			return;
+		}
+
+		String json;
+		try
+		{
+			json = gson.toJson(fight, FightPerformance.class);
+		}
+		catch (Exception e)
+		{
+			log.warn("Failed to serialize fight for PvP-Hub upload: {}", e.getMessage());
+			return;
+		}
+
+		RequestBody body = RequestBody.create(JSON, json);
+		Request request = new Request.Builder()
+			.url(UPLOAD_URL)
+			.post(body)
+			.build();
+
+		httpClient.newCall(request).enqueue(new Callback()
+		{
+			@Override
+			public void onFailure(Call call, IOException e)
+			{
+				log.warn("PvP-Hub upload failed (network error): {}", e.getMessage());
+			}
+
+			@Override
+			public void onResponse(Call call, Response response)
+			{
+				try
+				{
+					if (response.isSuccessful())
+					{
+						log.info("PvP-Hub upload successful for fight {} (HTTP {})", fight.getFightId(), response.code());
+					}
+					else
+					{
+						log.warn("PvP-Hub upload returned HTTP {}: {}", response.code(),
+							response.body() != null ? response.body().string() : "no body");
+					}
+				}
+				catch (IOException e)
+				{
+					log.warn("Error reading PvP-Hub upload response: {}", e.getMessage());
+				}
+				finally
+				{
+					response.close();
+				}
+			}
+		});
+	}
+}

--- a/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
@@ -35,8 +35,12 @@ import lombok.Getter;
 import lombok.Setter;
 import matsyir.pvpperformancetracker.controllers.PvpDamageCalc;
 import static matsyir.pvpperformancetracker.PvpPerformanceTrackerPlugin.PLUGIN;
+import net.runelite.api.EquipmentInventorySlot;
 import net.runelite.api.GraphicID;
 import net.runelite.api.HeadIcon;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.Player;
 import net.runelite.client.chat.ChatMessageBuilder;
 import org.apache.commons.text.WordUtils;
@@ -167,6 +171,15 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 
 	@Expose
 	@Getter
+	@SerializedName("R")
+	private Integer attackerRingItemId;
+	@Expose
+	@Getter
+	@SerializedName("A")
+	private Integer attackerAmmoItemId;
+
+	@Expose
+	@Getter
 	private int expectedHits; // Declare expectedHits field
 
 	@Expose
@@ -247,6 +260,8 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 		this.maxHit = pvpDamageCalc.getMaxHit();
 		this.splash = animationData.attackStyle == AnimationData.AttackStyle.MAGIC && defender.getGraphic() == GraphicID.SPLASH;
 		this.attackerLevels = levels; // CAN BE NULL
+		this.attackerRingItemId = getLocalPlayerRingItemId(attacker);
+		this.attackerAmmoItemId = getLocalPlayerAmmoItemId(attacker);
 
 		// defender data
 		this.defenderGear = defender.getPlayerComposition().getEquipmentIds();
@@ -269,6 +284,8 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 
 		this.attackerLevels = levels;
 		this.attackerOffensivePray = attackerOffensivePray;
+		this.attackerRingItemId = getLocalPlayerRingItemId(PLUGIN.getClient().getLocalPlayer());
+		this.attackerAmmoItemId = getLocalPlayerAmmoItemId(PLUGIN.getClient().getLocalPlayer());
 		this.actualDamageSum = 0;
 	}
 
@@ -294,6 +311,8 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 		this.defenderElyProc = e.defenderElyProc;
 		this.defenderSotdMeleeReductionProc = e.defenderSotdMeleeReductionProc;
 		this.attackerLevels = e.attackerLevels;
+		this.attackerRingItemId = e.attackerRingItemId;
+		this.attackerAmmoItemId = e.attackerAmmoItemId;
 
 		// defender data
 		this.defenderGear = e.defenderGear;
@@ -302,6 +321,68 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 		this.expectedHits = PvpPerformanceTrackerUtils.getExpectedHits(e.animationData);
 		this.matchedHitsCount = 0;
 		this.actualDamageSum = 0;
+	}
+
+	private boolean isLocalPlayer(Player player)
+	{
+		if (player == null)
+		{
+			return false;
+		}
+		Player localPlayer = PLUGIN.getClient().getLocalPlayer();
+		if (localPlayer == null || localPlayer.getName() == null || player.getName() == null)
+		{
+			return false;
+		}
+
+		String localName = localPlayer.getName().replace("\u00a0", " ").replace("_", " ").trim().toUpperCase();
+		String playerName = player.getName().replace("\u00a0", " ").replace("_", " ").trim().toUpperCase();
+
+		return localName.equals(playerName);
+	}
+
+	private Integer getLocalPlayerRingItemId(Player attacker)
+	{
+		if (!isLocalPlayer(attacker))
+		{
+			return null;
+		}
+
+		ItemContainer worn = PLUGIN.getClient().getItemContainer(InventoryID.EQUIPMENT);
+		if (worn == null)
+		{
+			return null;
+		}
+
+		Item ring = worn.getItem(EquipmentInventorySlot.RING.getSlotIdx());
+		if (ring == null || ring.getId() <= 0)
+		{
+			return null;
+		}
+
+		return ring.getId();
+	}
+
+	private Integer getLocalPlayerAmmoItemId(Player attacker)
+	{
+		if (!isLocalPlayer(attacker))
+		{
+			return null;
+		}
+
+		ItemContainer worn = PLUGIN.getClient().getItemContainer(InventoryID.EQUIPMENT);
+		if (worn == null)
+		{
+			return null;
+		}
+
+		Item ammo = worn.getItem(EquipmentInventorySlot.AMMO.getSlotIdx());
+		if (ammo == null || ammo.getId() <= 0)
+		{
+			return null;
+		}
+
+		return ammo.getId();
 	}
 
 	// randomized entry used for testing

--- a/src/main/java/matsyir/pvpperformancetracker/models/RangeAmmoData.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/RangeAmmoData.java
@@ -41,6 +41,39 @@ public interface RangeAmmoData
 		StrongBoltAmmo.OPAL_DRAGON_BOLTS_E
 	};
 
+	static RangeAmmoData fromId(int itemId)
+	{
+		for (BoltAmmo ammo : BoltAmmo.values())
+		{
+			if (ammo.getItemId() == itemId)
+			{
+				return ammo;
+			}
+		}
+		for (StrongBoltAmmo ammo : StrongBoltAmmo.values())
+		{
+			if (ammo.getItemId() == itemId)
+			{
+				return ammo;
+			}
+		}
+		for (DartAmmo ammo : DartAmmo.values())
+		{
+			if (ammo.getItemId() == itemId)
+			{
+				return ammo;
+			}
+		}
+		for (OtherAmmo ammo : OtherAmmo.values())
+		{
+			if (ammo.getItemId() == itemId)
+			{
+				return ammo;
+			}
+		}
+		return null;
+	}
+
 	int getItemId(); // itemIDs used for DISPLAYING bolts, not getting them.
 	int getRangeStr();
 	double getBonusMaxHit(int rangeLevel); // damage bonus from bolt specs.
@@ -55,8 +88,8 @@ public interface RangeAmmoData
 	enum BoltAmmo implements RangeAmmoConfigData
 	{
 		RUNITE_BOLTS("Runite Bolts", 9169, 115, 1),
-		DRAGONSTONE_BOLTS_E("Dstone Bolts (e)", 9281, 117, 1, .2, 0.06),
-		DIAMOND_BOLTS_E("Diamond Bolts (e)", 9277, 105, 1.015);
+		DRAGONSTONE_BOLTS_E("Dstone Bolts (e)", 9244, 117, 1, .2, 0.06),
+		DIAMOND_BOLTS_E("Diamond Bolts (e)", 9243, 105, 1.015);
 
 		static EquipmentData[] WEAPONS_USING = { EquipmentData.RUNE_CROSSBOW };
 
@@ -102,11 +135,11 @@ public interface RangeAmmoData
 	enum StrongBoltAmmo implements RangeAmmoConfigData
 	{
 		RUNITE_BOLTS("Runite Bolts", 9169, 115, 1),
-		DRAGONSTONE_BOLTS_E("Dstone Bolts (e)", 9281, 117, 1, .2, 0.06),
-		DIAMOND_BOLTS_E("Diamond Bolts (e)", 9277, 105, 1.015),
-		DRAGONSTONE_DRAGON_BOLTS_E("Dstone DBolts (e)", 1668, 122, 1, .2, .06),
-		OPAL_DRAGON_BOLTS_E("Opal DBolts (e)", 8729, 122, 1, .1, .05),
-		DIAMOND_DRAGON_BOLTS_E("Diamond DBolts (e)", 1690, 122, 1.015);
+		DRAGONSTONE_BOLTS_E("Dstone Bolts (e)", 9244, 117, 1, .2, 0.06),
+		DIAMOND_BOLTS_E("Diamond Bolts (e)", 9243, 105, 1.015),
+		DRAGONSTONE_DRAGON_BOLTS_E("Dstone DBolts (e)", 21948, 122, 1, .2, .06),
+		OPAL_DRAGON_BOLTS_E("Opal DBolts (e)", 21932, 122, 1, .1, .05),
+		DIAMOND_DRAGON_BOLTS_E("Diamond DBolts (e)", 21946, 122, 1.015);
 
 		static EquipmentData[] WEAPONS_USING = {
 			EquipmentData.ARMADYL_CROSSBOW,
@@ -193,8 +226,8 @@ public interface RangeAmmoData
 	@Getter
 	public enum OtherAmmo implements RangeAmmoData
 	{
-		AMETHYST_ARROWS(4770, 55),
-		DRAGON_ARROW(11216, 60),
+		AMETHYST_ARROWS(21326, 55),
+		DRAGON_ARROW(11212, 60),
 		DRAGON_JAVELIN(19484, 150),
 		BOLT_RACK(4740, 55),
 		MOONLIGHT_ANTLER_BOLTS(28878, 60);

--- a/src/main/java/matsyir/pvpperformancetracker/models/RingData.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/RingData.java
@@ -60,4 +60,16 @@ public enum RingData
 	{
 		return name;
 	}
+
+	public static RingData fromId(int itemId)
+	{
+		for (RingData ring : values())
+		{
+			if (ring.itemId == itemId)
+			{
+				return ring;
+			}
+		}
+		return NONE;
+	}
 }

--- a/src/main/java/matsyir/pvpperformancetracker/utils/FightIdGenerator.java
+++ b/src/main/java/matsyir/pvpperformancetracker/utils/FightIdGenerator.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021, Matsyir <https://github.com/Matsyir>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package matsyir.pvpperformancetracker.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Generates a deterministic 10-character fight ID (A-Z, 0-9) from shared game state
+ * that both clients in a fight can independently compute without communication.
+ *
+ * The ID is derived from:
+ * - Both player names (sorted alphabetically so order doesn't matter)
+ * - The world number
+ * - The game tick of the first attack (server-synchronized)
+ */
+public class FightIdGenerator
+{
+	private static final char[] BASE36_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+	private static final int ID_LENGTH = 10;
+
+	/**
+	 * Generate a deterministic 10-character fight ID from shared game state.
+	 * Both clients will produce the same ID because all inputs are derived from
+	 * shared game state and NTP-synchronized system clocks.
+	 *
+	 * The epoch time is rounded to the nearest 10-second window to absorb any
+	 * minor clock differences between clients (typically < 100ms with NTP).
+	 *
+	 * @param name1      one player's RSN
+	 * @param name2      the other player's RSN
+	 * @param world      the OSRS world number
+	 * @param epochMillis the current system time in milliseconds (Instant.now().toEpochMilli())
+	 * @return a 10-character uppercase alphanumeric string matching [A-Z0-9]{10}
+	 */
+	public static String generateFightId(String name1, String name2, int world, long epochMillis)
+	{
+		// Normalize name characters: replace underscores and non-breaking spaces with standard spaces,
+		// trim, and uppercase, then sort alphabetically so both clients produce the same order.
+		String n1 = name1.replace("\u00a0", " ").replace("_", " ").trim().toUpperCase();
+		String n2 = name2.replace("\u00a0", " ").replace("_", " ").trim().toUpperCase();
+		if (n1.compareTo(n2) > 0)
+		{
+			String temp = n1;
+			n1 = n2;
+			n2 = temp;
+		}
+
+		// Round to 10-second granularity so both clients land in the same bucket
+		// even with minor clock differences (NTP typically syncs within <100ms).
+		long roundedEpoch = epochMillis / 10000;
+		String seed = n1 + ":" + n2 + ":" + world + ":" + roundedEpoch;
+
+		byte[] hash;
+		try
+		{
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			hash = digest.digest(seed.getBytes(StandardCharsets.UTF_8));
+		}
+		catch (NoSuchAlgorithmException e)
+		{
+			// SHA-256 is guaranteed to be available on all Java platforms
+			throw new RuntimeException("SHA-256 not available", e);
+		}
+
+		// Convert first 8 bytes of the hash to a long (unsigned), then base-36 encode
+		// to produce a 10-character ID from the A-Z0-9 character set.
+		// We use the absolute value and mask to ensure positive values.
+		char[] result = new char[ID_LENGTH];
+		// Use first 8 bytes as a long seed for base-36 conversion
+		long value = 0;
+		for (int i = 0; i < 8; i++)
+		{
+			value = (value << 8) | (hash[i] & 0xFF);
+		}
+		// Ensure positive
+		value = value & Long.MAX_VALUE;
+
+		for (int i = ID_LENGTH - 1; i >= 0; i--)
+		{
+			result[i] = BASE36_CHARS[(int) (value % 36)];
+			value /= 36;
+		}
+
+		return new String(result);
+	}
+}

--- a/src/main/java/matsyir/pvpperformancetracker/views/FightLogDetailFrame.java
+++ b/src/main/java/matsyir/pvpperformancetracker/views/FightLogDetailFrame.java
@@ -48,6 +48,7 @@ import matsyir.pvpperformancetracker.controllers.FightPerformance;
 import matsyir.pvpperformancetracker.controllers.Fighter;
 import matsyir.pvpperformancetracker.controllers.PvpDamageCalc;
 import matsyir.pvpperformancetracker.models.RangeAmmoData;
+import matsyir.pvpperformancetracker.models.RingData;
 import matsyir.pvpperformancetracker.utils.PvpPerformanceTrackerUtils;
 import net.runelite.api.Skill;
 import net.runelite.api.SpriteID;
@@ -85,6 +86,11 @@ class FightLogDetailFrame extends JFrame
 
 	// this is a regular fightLogDetailFrame, for a normal non-merged fight.
 	FightLogDetailFrame(FightPerformance fight, FightLogEntry log, int rowIdx, Point location)
+	{
+		this(fight, log, null, rowIdx, location);
+	}
+
+	FightLogDetailFrame(FightPerformance fight, FightLogEntry log, FightLogEntry defenderLog, int rowIdx, Point location)
 	{
 		super("Fight Log Details - " + fight.getCompetitor().getName() + " vs " + fight.getOpponent().getName()
 			+ " on world " + fight.getWorld());
@@ -258,18 +264,23 @@ class FightLogDetailFrame extends JFrame
 		// equipment stats line (stab attack, slash attack, etc)
 		JPanel equipmentStatsLine = new JPanel(new BorderLayout());
 		JLabel attackerStatsLabel = new JLabel();
-		PLUGIN.getClientThread().invokeLater(() ->
-			attackerStatsLabel.setText(getItemEquipmentStatsString(log.getAttackerGear())));
+		PLUGIN.getClientThread().invokeLater(() -> {
+			RingData ringUsed = log.getAttackerRingItemId() != null ? RingData.fromId(log.getAttackerRingItemId()) : CONFIG.ringChoice();
+			attackerStatsLabel.setText(getItemEquipmentStatsString(log.getAttackerGear(), log.getAttackerAmmoItemId(), ringUsed));
+		});
 		equipmentStatsLine.add(attackerStatsLabel, BorderLayout.WEST);
 
 		JLabel defenderStatsLabel = new JLabel();
-		PLUGIN.getClientThread().invokeLater(() ->
-			defenderStatsLabel.setText(getItemEquipmentStatsString(log.getDefenderGear())));
+		PLUGIN.getClientThread().invokeLater(() -> {
+			RingData ringUsed = (defenderLog != null && defenderLog.getAttackerRingItemId() != null) ? RingData.fromId(defenderLog.getAttackerRingItemId()) : CONFIG.ringChoice();
+			Integer ammoId = (defenderLog != null) ? defenderLog.getAttackerAmmoItemId() : null;
+			defenderStatsLabel.setText(getItemEquipmentStatsString(log.getDefenderGear(), ammoId, ringUsed));
+		});
 		equipmentStatsLine.add(defenderStatsLabel, BorderLayout.EAST);
 
 		JPanel equipmentRenderLine = new JPanel(new BorderLayout());
-		JPanel attackerEquipmentRender = getEquipmentRender(log.getAttackerGear());
-		JPanel defenderEquipmentRender = getEquipmentRender(log.getDefenderGear());
+		JPanel attackerEquipmentRender = getEquipmentRender(log.getAttackerGear(), log, true);
+		JPanel defenderEquipmentRender = getEquipmentRender(log.getDefenderGear(), defenderLog != null ? defenderLog : log, defenderLog != null);
 		equipmentRenderLine.add(attackerEquipmentRender, BorderLayout.WEST);
 		equipmentRenderLine.add(defenderEquipmentRender, BorderLayout.EAST);
 
@@ -297,7 +308,7 @@ class FightLogDetailFrame extends JFrame
 	// extra-detailed frame for a merged fight, which has both an attacker and defender log for each attack
 	FightLogDetailFrame(AnalyzedFightPerformance fight, FightLogEntry attackerLog, FightLogEntry defenderLog, int rowIdx, Point location)
 	{
-		this(fight, attackerLog, rowIdx, location);
+		this((FightPerformance) fight, attackerLog, defenderLog, rowIdx, location);
 
 		// attacker lvls
 		CombatLevels aLvls = attackerLog.getAttackerLevels();
@@ -337,7 +348,7 @@ class FightLogDetailFrame extends JFrame
 		});
 	}
 
-	private JPanel getEquipmentRender(int[] itemIds)
+	private JPanel getEquipmentRender(int[] itemIds, FightLogEntry log, boolean isAttacker)
 	{
 		JPanel equipmentRender = new JPanel();
 		equipmentRender.setLayout(new BoxLayout(equipmentRender, BoxLayout.Y_AXIS));
@@ -360,12 +371,25 @@ class FightLogDetailFrame extends JFrame
 		capeLine.add(cape, BorderLayout.WEST);
 		capeLine.add(amulet, BorderLayout.CENTER);
 
-		// ammo: get config's ammo for current weapon
-		RangeAmmoData weaponAmmo = EquipmentData.getWeaponAmmo(EquipmentData.fromId(fixItemId(itemIds[KitType.WEAPON.getIndex()])));
-		if (weaponAmmo != null)
+		// ammo: use local-player equipped ammo when this attack was performed by us; otherwise fall back to inferred weapon ammo in config
+		int ammoId = -1;
+		if (isAttacker && log.getAttackerAmmoItemId() != null && log.getAttackerAmmoItemId() > 0)
+		{
+			ammoId = log.getAttackerAmmoItemId();
+		}
+		else
+		{
+			RangeAmmoData weaponAmmo = EquipmentData.getWeaponAmmo(EquipmentData.fromId(fixItemId(itemIds[KitType.WEAPON.getIndex()])));
+			if (weaponAmmo != null)
+			{
+				ammoId = weaponAmmo.getItemId();
+			}
+		}
+
+		if (ammoId > 0)
 		{
 			JLabel ammo = new JLabel();
-			PLUGIN.addItemToLabelIfValid(ammo, weaponAmmo, false, null);
+			PLUGIN.addItemToLabelIfValid(ammo, ammoId, false, null);
 			capeLine.add(ammo, BorderLayout.EAST);
 		}
 
@@ -388,8 +412,18 @@ class FightLogDetailFrame extends JFrame
 		PLUGIN.addItemToLabelIfValid(gloves, itemIds[KitType.HANDS.getIndex()]);
 		JLabel boots = new JLabel();
 		PLUGIN.addItemToLabelIfValid(boots, itemIds[KitType.BOOTS.getIndex()]);
+		
 		JLabel ring = new JLabel();
-		PLUGIN.addItemToLabelIfValid(ring, CONFIG.ringChoice().getItemId(), false, () -> {
+		int ringId = -1;
+		if (isAttacker && log.getAttackerRingItemId() != null && log.getAttackerRingItemId() > 0)
+		{
+			ringId = log.getAttackerRingItemId();
+		}
+		else
+		{
+			ringId = CONFIG.ringChoice().getItemId();
+		}
+		PLUGIN.addItemToLabelIfValid(ring, ringId, false, () -> {
 			validate();
 			repaint();
 		});
@@ -409,13 +443,43 @@ class FightLogDetailFrame extends JFrame
 	//
 	String getItemEquipmentStatsString(int[] equipment)
 	{
-		ItemEquipmentStats stats = PvpDamageCalc.calculateBonusesToStats(equipment);
-		// ammo: get config's ammo for current weapon
-		RangeAmmoData weaponAmmo = EquipmentData.getWeaponAmmo(EquipmentData.fromId(fixItemId(equipment[KitType.WEAPON.getIndex()])));
+		return getItemEquipmentStatsString(equipment, null, CONFIG.ringChoice());
+	}
+
+	String getItemEquipmentStatsString(int[] equipment, Integer ammoId, RingData ringUsed)
+	{
+		int[] bonuses = PvpDamageCalc.calculateBonuses(equipment, ringUsed);
+		ItemEquipmentStats stats = ItemEquipmentStats.builder()
+			.astab(bonuses[0])	// 0
+			.aslash(bonuses[1])	// 1
+			.acrush(bonuses[2])	// 2
+			.amagic(bonuses[3])	// 3
+			.arange(bonuses[4])	// 4
+			.dstab(bonuses[5])		// 5
+			.dslash(bonuses[6])		// 6
+			.dcrush(bonuses[7])		// 7
+			.dmagic(bonuses[8])		// 8
+			.drange(bonuses[9])		// 9
+			.str(bonuses[10])	// 10
+			.rstr(bonuses[11]) 	// 11
+			.mdmg(bonuses[12])	// 12
+			.build();
 		int ammoRangeStr = 0;
-		if (weaponAmmo != null)
+		if (ammoId != null && ammoId > 0)
 		{
-			ammoRangeStr = weaponAmmo.getRangeStr();
+			RangeAmmoData ammoData = RangeAmmoData.fromId(ammoId);
+			if (ammoData != null)
+			{
+				ammoRangeStr = ammoData.getRangeStr();
+			}
+		}
+		else
+		{
+			RangeAmmoData weaponAmmo = EquipmentData.getWeaponAmmo(EquipmentData.fromId(fixItemId(equipment[KitType.WEAPON.getIndex()])));
+			if (weaponAmmo != null)
+			{
+				ammoRangeStr = weaponAmmo.getRangeStr();
+			}
 		}
 		String sep = "<br/>&nbsp;&nbsp;";
 		return "<html><strong>Attack bonus</strong>" + sep +


### PR DESCRIPTION
Hey there ~ While talking with some friends in Discord VC watching the start of DMM today, we both felt that the advanced analysis part of the plugin is underused AND I thought it would be nice to have these PvP kills mapped right away on DMM Radar or another website...

So I cooked this up using a lot of resources from previous projects ~ https://osrs.pvp-hub.com/ 

Here's the source as well if you don't want to click the direct link ~ 
https://github.com/LogicalSoIutions/osrs-pvp-performance-tracker-website/ 

This is just hosted on a Hetzner Cloud VPS along with my 30+ other small web-apps that I've made for various things over the years. 

I tested it with about twenty fight between my two accounts; I left two fights up as examples on the website. 

IF unwanted, no hard feelings at all! Thanks for the consideration. 
