### PR TITLE
Add's a delay to the JSON Payload

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
@@ -47,6 +47,33 @@ public interface PvpPerformanceTrackerConfig extends Config
 		EITHER
 	}
 
+	enum PvpHubVisibilityDelay
+	{
+		RANDOM_6_20("Random (6-20 minutes)", 0),
+		INSTANT("Instant", 0),
+		MINUTES_15("15 minutes", 15 * 60),
+		MINUTES_30("30 minutes", 30 * 60),
+		HOUR_1("1 hour", 60 * 60),
+		HOUR_2("2 hours", 2 * 60 * 60);
+
+		@Getter
+		private final String displayName;
+		@Getter
+		private final int delaySeconds;
+
+		PvpHubVisibilityDelay(String displayName, int delaySeconds)
+		{
+			this.displayName = displayName;
+			this.delaySeconds = delaySeconds;
+		}
+
+		@Override
+		public String toString()
+		{
+			return displayName;
+		}
+	}
+
 	int LEVEL_MIN = 1;
 	int LEVEL_MAX = 120;
 
@@ -135,13 +162,26 @@ public interface PvpPerformanceTrackerConfig extends Config
 	@ConfigItem(
 		keyName = "uploadFightsToPvpHub",
 		name = "Upload Fights to PvP-Hub.com",
-		description = "When enabled, fights will be assigned a shared ID and uploaded to PvP-Hub.com after they end.",
+		description = "When enabled, fights will be assigned a shared ID and uploaded to PvP-Hub.com after they end." +
+			"<br>Public visibility follows the PvP-Hub upload delay setting below.",
 		warning = "This feature will submit your RSN, fight logs, and IP address to a 3rd-party server not controlled or verified by Runelite developers.",
 		position = 1200
 	)
 	default boolean uploadFightsToPvpHub()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "pvpHubVisibilityDelay",
+		name = "PvP-Hub Upload Delay",
+		description = "Choose how long uploaded fights stay hidden before becoming public on PvP-Hub." +
+			"<br>Random uses a fresh 6-20 minute delay for each uploaded fight.",
+		position = 1210
+	)
+	default PvpHubVisibilityDelay pvpHubVisibilityDelay()
+	{
+		return PvpHubVisibilityDelay.RANDOM_6_20;
 	}
 
 	// ================================= Overlay =================================

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubUploader.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubUploader.java
@@ -25,7 +25,9 @@
 package matsyir.pvpperformancetracker.controllers;
 
 import com.google.gson.Gson;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
+import matsyir.pvpperformancetracker.PvpPerformanceTrackerConfig;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.MediaType;
@@ -36,6 +38,8 @@ import okhttp3.Response;
 
 import java.io.IOException;
 
+import static matsyir.pvpperformancetracker.PvpPerformanceTrackerPlugin.CONFIG;
+
 /**
  * Handles uploading fight data to PvP-Hub.com.
  * Uploads are asynchronous and failures are silently logged.
@@ -45,6 +49,8 @@ public class PvpHubUploader
 {
 	private static final String UPLOAD_URL = "https://osrs.pvp-hub.com/api/fights";
 	private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+	static final int RANDOM_DELAY_MIN_SECONDS = 6 * 60;
+	static final int RANDOM_DELAY_MAX_SECONDS = 20 * 60;
 
 	/**
 	 * Asynchronously uploads a completed fight to PvP-Hub.com.
@@ -65,7 +71,8 @@ public class PvpHubUploader
 		String json;
 		try
 		{
-			json = gson.toJson(fight, FightPerformance.class);
+			int publicDelaySeconds = resolvePublicDelaySeconds(CONFIG.pvpHubVisibilityDelay());
+			json = serializeFightUpload(fight, gson, publicDelaySeconds);
 		}
 		catch (Exception e)
 		{
@@ -112,5 +119,44 @@ public class PvpHubUploader
 				}
 			}
 		});
+	}
+
+	static int resolvePublicDelaySeconds(PvpPerformanceTrackerConfig.PvpHubVisibilityDelay delayMode)
+	{
+		PvpPerformanceTrackerConfig.PvpHubVisibilityDelay safeDelayMode =
+			delayMode != null ? delayMode : PvpPerformanceTrackerConfig.PvpHubVisibilityDelay.RANDOM_6_20;
+		if (safeDelayMode == PvpPerformanceTrackerConfig.PvpHubVisibilityDelay.RANDOM_6_20)
+		{
+			return ThreadLocalRandom.current().nextInt(RANDOM_DELAY_MIN_SECONDS, RANDOM_DELAY_MAX_SECONDS + 1);
+		}
+
+		return safeDelayMode.getDelaySeconds();
+	}
+
+	static String serializeFightUpload(FightPerformance fight, Gson gson, int publicDelaySeconds)
+	{
+		return gson.toJson(new FightUploadPayload(fight, publicDelaySeconds));
+	}
+
+	static final class FightUploadPayload
+	{
+		final Fighter c;
+		final Fighter o;
+		final long t;
+		final String fightID;
+		final matsyir.pvpperformancetracker.models.FightType l;
+		final int w;
+		final int publicDelaySeconds;
+
+		FightUploadPayload(FightPerformance fight, int publicDelaySeconds)
+		{
+			this.c = fight.competitor;
+			this.o = fight.opponent;
+			this.t = fight.lastFightTime;
+			this.fightID = fight.getFightId();
+			this.l = fight.getFightType();
+			this.w = fight.getWorld();
+			this.publicDelaySeconds = publicDelaySeconds;
+		}
 	}
 }

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubUploader.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubUploader.java
@@ -25,6 +25,8 @@
 package matsyir.pvpperformancetracker.controllers;
 
 import com.google.gson.Gson;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
 import matsyir.pvpperformancetracker.PvpPerformanceTrackerConfig;
@@ -140,12 +142,25 @@ public class PvpHubUploader
 
 	static final class FightUploadPayload
 	{
+		@Expose
+		@SerializedName("c")
 		final Fighter c;
+		@Expose
+		@SerializedName("o")
 		final Fighter o;
+		@Expose
+		@SerializedName("t")
 		final long t;
+		@Expose
+		@SerializedName("fightID")
 		final String fightID;
+		@Expose
+		@SerializedName("l")
 		final matsyir.pvpperformancetracker.models.FightType l;
+		@Expose
+		@SerializedName("w")
 		final int w;
+		@Expose
 		final int publicDelaySeconds;
 
 		FightUploadPayload(FightPerformance fight, int publicDelaySeconds)


### PR DESCRIPTION
Add delay to JSON payload - website handles delaying the display of data.

Went this route because if people pick 5 hours and close their client, it will never upload. 