### PR TITLE
Feat/hidden name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,28 @@ This feature is completely optional.
 
 - The setting is disabled by default.
 - If the checkbox is disabled, no data is sent to the server. If it is enabled, data is only sent to the server when you
-  finish a fight. This data includes your fight data, RSN, IP, and a uniquely generated fight ID.
+  finish a fight. This data includes your fight data, IP, and a uniquely generated fight ID. It includes your RSN unless
+  you also enable the "Hide RSN on PvP-Hub" option.
 - If you enable it, and your opponent also has it enabled, the website can automatically use Advanced Analysis.
 - Advanced Analysis lets you view the full fight, including more accurate calculations, extra details such as ammo,
   rings used, and more.
 - If your opponent does not have the plugin, or has this setting disabled, the plugin will use your existing gear settings instead.
+
+## Hide RSN on PvP-Hub
+
+If "Hide RSN on PvP-Hub" is enabled, the plugin replaces your RSN in PvP-Hub uploads with a generated name like
+`Hidden-ABCDE`.
+
+This is not based on your device, hardware, Windows username, or RuneScape account. The plugin creates a random ID once,
+stores it locally in your RuneLite profile config, and derives the `Hidden-XXXXX` name from that ID. The hidden name is
+stable so your uploaded fights can still be grouped under the same hidden identity.
+
+Your hidden name is shown in the PvP Performance Tracker side panel while this setting is enabled. If you want to keep
+that hidden identity private, do not show the panel on stream, screenshots, or screen share.
+
+To change your hidden name, reset the stored anonymous ID. You can do this with RuneLite's native config reset button, or
+manually by removing the `pvpHubAnonymousId` value from your RuneLite profile data for this plugin. After it is removed,
+the plugin will generate a new random ID the next time the hidden name is needed.
 
 -------------------------------
 I am happy to see other features/stats come into this plugin in the future, feel free to submit issues/suggestions &

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
@@ -164,7 +164,7 @@ public interface PvpPerformanceTrackerConfig extends Config
 		name = "Upload Fights to PvP-Hub.com",
 		description = "When enabled, fights will be assigned a shared ID and uploaded to PvP-Hub.com after they end." +
 			"<br>Public visibility follows the PvP-Hub upload delay setting below.",
-		warning = "This feature will submit your RSN, fight logs, and IP address to a 3rd-party server not controlled or verified by Runelite developers.",
+		warning = "This feature will submit fight logs and IP address to a 3rd-party server not controlled or verified by Runelite developers. Your RSN is submitted unless PvP-Hub RSN privacy is enabled.",
 		position = 1200
 	)
 	default boolean uploadFightsToPvpHub()
@@ -182,6 +182,30 @@ public interface PvpPerformanceTrackerConfig extends Config
 	default PvpHubVisibilityDelay pvpHubVisibilityDelay()
 	{
 		return PvpHubVisibilityDelay.RANDOM_6_20;
+	}
+
+	@ConfigItem(
+		keyName = "hideRsnOnPvpHub",
+		name = "Hide RSN on PvP-Hub",
+		description = "Replace your RSN in PvP-Hub uploads with the hidden name shown in the side panel.",
+		warning = "Your PvP-Hub hidden name will be shown in the PvP Performance Tracker panel. If you want to keep that hidden identity private, do not show the panel on stream, screenshots, or screen share.",
+		position = 1220
+	)
+	default boolean hideRsnOnPvpHub()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "pvpHubAnonymousId",
+		name = "PvP-Hub Anonymous ID",
+		description = "Hidden local random ID used to derive your PvP-Hub hidden name.",
+		position = 1230,
+		hidden = true
+	)
+	default String pvpHubAnonymousId()
+	{
+		return "";
 	}
 
 	// ================================= Overlay =================================

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPanel.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPanel.java
@@ -50,6 +50,8 @@ class PvpPerformanceTrackerPanel extends PluginPanel
 	// The main fight history container, this will hold all the individual FightPerformancePanels.
 	private final JPanel fightHistoryContainer = new JPanel();
 	private final TotalStatsPanel totalStatsPanel = new TotalStatsPanel();
+	private final JPanel pvpHubHiddenNameLine = new JPanel(new BorderLayout());
+	private final JLabel pvpHubHiddenNameLabel = new JLabel();
 
 	private final PvpPerformanceTrackerPlugin plugin;
 	private final PvpPerformanceTrackerConfig config;
@@ -69,6 +71,18 @@ class PvpPerformanceTrackerPanel extends PluginPanel
 		fightHistoryContainer.setLayout(new BoxLayout(fightHistoryContainer, BoxLayout.Y_AXIS));
 
 		add(totalStatsPanel);
+
+		JLabel pvpHubHiddenNameTitle = new JLabel("PvP-Hub Hidden Name:");
+		pvpHubHiddenNameTitle.setHorizontalAlignment(SwingConstants.LEFT);
+		pvpHubHiddenNameLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+		pvpHubHiddenNameLabel.setToolTipText("Read-only name used when Hide RSN on PvP-Hub is enabled.");
+		pvpHubHiddenNameLine.add(pvpHubHiddenNameTitle, BorderLayout.WEST);
+		pvpHubHiddenNameLine.add(pvpHubHiddenNameLabel, BorderLayout.EAST);
+		pvpHubHiddenNameLine.setMaximumSize(new Dimension(PANEL_WIDTH, (int)pvpHubHiddenNameLine.getPreferredSize().getHeight()));
+		updatePvpHubHiddenName();
+
+		add(Box.createRigidArea(new Dimension(0, 4)));
+		add(pvpHubHiddenNameLine);
 
 		// add filter line with label & text field.
 		JPanel filterLine = new JPanel(new BorderLayout());
@@ -215,5 +229,14 @@ class PvpPerformanceTrackerPanel extends PluginPanel
 	public void setConfigWarning(boolean enable)
 	{
 		totalStatsPanel.setConfigWarning(enable);
+	}
+
+	public void updatePvpHubHiddenName()
+	{
+		boolean showHiddenName = config.hideRsnOnPvpHub();
+		pvpHubHiddenNameLine.setVisible(showHiddenName);
+		pvpHubHiddenNameLabel.setText(showHiddenName ? plugin.getPvpHubHiddenName() : "");
+		revalidate();
+		repaint();
 	}
 }

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -70,6 +70,7 @@ import matsyir.pvpperformancetracker.models.FightLogEntry;
 import matsyir.pvpperformancetracker.models.HitsplatInfo;
 import matsyir.pvpperformancetracker.models.RangeAmmoData;
 import matsyir.pvpperformancetracker.models.oldVersions.FightPerformance__1_5_5;
+import matsyir.pvpperformancetracker.utils.PvpHubPrivacy;
 import matsyir.pvpperformancetracker.utils.PvpPerformanceTrackerUtils;
 import net.runelite.api.Actor;
 import net.runelite.api.ChatMessageType;
@@ -346,6 +347,12 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 				break;
 			case "robeHitFilter":
 				recalculateAllRobeHits(true);
+				break;
+			case "hideRsnOnPvpHub":
+				if (panel != null)
+				{
+					panel.updatePvpHubHiddenName();
+				}
 				break;
 				// potential future code for level presets/dynamic config if RL ever supports it.
 //			case "attackLevel":
@@ -1300,7 +1307,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 					&& !currentFight.getFightId().isEmpty())
 			{
 				final FightPerformance fightToUpload = currentFight;
-				executor.submit(() -> PvpHubUploader.uploadFight(fightToUpload, GSON, httpClient));
+				final String hiddenName = config.hideRsnOnPvpHub() ? getPvpHubHiddenName() : null;
+				executor.submit(() -> PvpHubUploader.uploadFight(fightToUpload, GSON, httpClient, hiddenName));
 			}
 		}
 		currentFight = null;
@@ -1699,5 +1707,17 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 	public void updateNameFilterConfig(String newFilterName)
 	{
 		configManager.setConfiguration(CONFIG_KEY, "nameFilter", newFilterName.trim().toLowerCase());
+	}
+
+	String getPvpHubHiddenName()
+	{
+		String anonymousId = config.pvpHubAnonymousId();
+		if (anonymousId == null || anonymousId.trim().isEmpty())
+		{
+			anonymousId = PvpHubPrivacy.createAnonymousId();
+			configManager.setConfiguration(CONFIG_KEY, "pvpHubAnonymousId", anonymousId);
+		}
+
+		return PvpHubPrivacy.hiddenNameFor(anonymousId);
 	}
 }

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubUploader.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubUploader.java
@@ -26,6 +26,7 @@
 package matsyir.pvpperformancetracker.controllers;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import java.util.concurrent.ThreadLocalRandom;
@@ -65,6 +66,19 @@ public class PvpHubUploader
 	 */
 	public static void uploadFight(FightPerformance fight, Gson gson, OkHttpClient httpClient)
 	{
+		uploadFight(fight, gson, httpClient, null);
+	}
+
+	/**
+	 * Asynchronously uploads a completed fight to PvP-Hub.com with an optional local-player hidden name.
+	 *
+	 * @param fight      the completed fight performance data
+	 * @param gson       the Gson instance configured for serialization
+	 * @param httpClient the OkHttpClient to use for the request
+	 * @param hiddenName when present, replaces the local competitor RSN in the upload payload
+	 */
+	public static void uploadFight(FightPerformance fight, Gson gson, OkHttpClient httpClient, String hiddenName)
+	{
 		if (fight == null || fight.getFightId() == null || fight.getFightId().isEmpty())
 		{
 			log.debug("Skipping PvP-Hub upload: fight or fightId is null/empty");
@@ -75,7 +89,7 @@ public class PvpHubUploader
 		try
 		{
 			int publicDelaySeconds = resolvePublicDelaySeconds(CONFIG.pvpHubVisibilityDelay());
-			json = serializeFightUpload(fight, gson, publicDelaySeconds);
+			json = serializeFightUpload(fight, gson, publicDelaySeconds, hiddenName);
 		}
 		catch (Exception e)
 		{
@@ -138,7 +152,18 @@ public class PvpHubUploader
 
 	static String serializeFightUpload(FightPerformance fight, Gson gson, int publicDelaySeconds)
 	{
-		return gson.toJson(new FightUploadPayload(fight, publicDelaySeconds));
+		return serializeFightUpload(fight, gson, publicDelaySeconds, null);
+	}
+
+	static String serializeFightUpload(FightPerformance fight, Gson gson, int publicDelaySeconds, String hiddenName)
+	{
+		JsonObject payload = gson.toJsonTree(new FightUploadPayload(fight, publicDelaySeconds)).getAsJsonObject();
+		if (hiddenName != null && !hiddenName.trim().isEmpty())
+		{
+			payload.getAsJsonObject("c").addProperty("n", hiddenName);
+		}
+
+		return gson.toJson(payload);
 	}
 
 	static final class FightUploadPayload

--- a/src/main/java/matsyir/pvpperformancetracker/utils/PvpHubPrivacy.java
+++ b/src/main/java/matsyir/pvpperformancetracker/utils/PvpHubPrivacy.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, LogicalSolutions <https://github.com/LogicalSolutions>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package matsyir.pvpperformancetracker.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+public final class PvpHubPrivacy
+{
+	private static final String HIDDEN_NAME_PREFIX = "Hidden-";
+	private static final char[] HIDDEN_NAME_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+	private static final int HIDDEN_NAME_LENGTH = 5;
+
+	private PvpHubPrivacy()
+	{
+	}
+
+	public static String createAnonymousId()
+	{
+		return UUID.randomUUID().toString();
+	}
+
+	public static String hiddenNameFor(String anonymousId)
+	{
+		if (anonymousId == null || anonymousId.trim().isEmpty())
+		{
+			throw new IllegalArgumentException("anonymousId must not be blank");
+		}
+
+		byte[] hash;
+		try
+		{
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			hash = digest.digest(anonymousId.trim().getBytes(StandardCharsets.UTF_8));
+		}
+		catch (NoSuchAlgorithmException e)
+		{
+			throw new RuntimeException("SHA-256 not available", e);
+		}
+
+		char[] suffix = new char[HIDDEN_NAME_LENGTH];
+		for (int i = 0; i < HIDDEN_NAME_LENGTH; i++)
+		{
+			suffix[i] = HIDDEN_NAME_CHARS[(hash[i] & 0xFF) % HIDDEN_NAME_CHARS.length];
+		}
+
+		return HIDDEN_NAME_PREFIX + new String(suffix);
+	}
+}

--- a/src/test/java/matsyir/pvpperformancetracker/PvpHubPrivacyTest.java
+++ b/src/test/java/matsyir/pvpperformancetracker/PvpHubPrivacyTest.java
@@ -1,0 +1,31 @@
+package matsyir.pvpperformancetracker;
+
+import matsyir.pvpperformancetracker.utils.PvpHubPrivacy;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PvpHubPrivacyTest
+{
+	@Test
+	public void hiddenNameForReturnsStableHiddenName()
+	{
+		String anonymousId = "9c7b2aca-6865-4b4c-9f2b-f1f3f9f08dbb";
+
+		String hiddenName = PvpHubPrivacy.hiddenNameFor(anonymousId);
+
+		assertEquals(hiddenName, PvpHubPrivacy.hiddenNameFor(anonymousId));
+		assertTrue(hiddenName.matches("^Hidden-[A-Z0-9]{5}$"));
+	}
+
+	@Test
+	public void hiddenNameForChangesWithAnonymousId()
+	{
+		String firstHiddenName = PvpHubPrivacy.hiddenNameFor("9c7b2aca-6865-4b4c-9f2b-f1f3f9f08dbb");
+		String secondHiddenName = PvpHubPrivacy.hiddenNameFor("2b1234e0-0861-4f0d-a488-c018a1d78a3f");
+
+		assertNotEquals(firstHiddenName, secondHiddenName);
+	}
+}


### PR DESCRIPTION
This allows people to upload their fights and sync their fights with their opponents while being anonymous to the rest of the internet.

If somebody accidentally leaks their "hidden" alias, they can easily reset it.