### PR TITLE
Fix empty fight history filter blocking new fights

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
@@ -812,16 +812,19 @@ public class FightPerformance implements Comparable<FightPerformance>
 
 	public boolean isRelevantForFilter(String filter, FightPerformancePanel.BackgroundStyle bgStyle)
 	{
-		return !filter.isEmpty()
-			&& (
-				(CONFIG.exactNameFilter() ?
-					(competitor.getName().toLowerCase().equals(filter) || opponent.getName().toLowerCase().equals(filter))
-					: (competitor.getName().toLowerCase().startsWith(filter) || opponent.getName().toLowerCase().startsWith(filter))
-				)
+		if (filter == null || filter.isEmpty())
+		{
+			return true;
+		}
+
+		return (CONFIG.exactNameFilter() ?
+			(competitor.getName().toLowerCase().equals(filter) || opponent.getName().toLowerCase().equals(filter))
+			: (competitor.getName().toLowerCase().startsWith(filter) || opponent.getName().toLowerCase().startsWith(filter))
+		)
 			|| (
 				bgStyle != FightPerformancePanel.BackgroundStyle.DEFAULT
 				&& bgStyle.isEnabled()
 				&& bgStyle.getName().toLowerCase().replace(" ", "").startsWith(filter)
-			));
+			);
 	}
 }


### PR DESCRIPTION
I think this problem was introduced in one of the PvP hub changes, having PvP hub enabled probably masked the issue because it triggers more panel rebuilds.

Solves #90