### PR TITLE
Fixes client perma loop

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -67,6 +67,7 @@ import lombok.extern.slf4j.Slf4j;
 import matsyir.pvpperformancetracker.controllers.FightPerformance;
 import matsyir.pvpperformancetracker.controllers.Fighter;
 import matsyir.pvpperformancetracker.controllers.PvpHubFightSync;
+import matsyir.pvpperformancetracker.controllers.PvpHubSyncRetryState;
 import matsyir.pvpperformancetracker.controllers.PvpHubUploader;
 import matsyir.pvpperformancetracker.models.AnimationData;
 import matsyir.pvpperformancetracker.models.CombatLevels;
@@ -151,6 +152,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 
 	// Last man standing map regions, including ferox enclave
 	private static final Set<Integer> LAST_MAN_STANDING_REGIONS = ImmutableSet.of(12344, 12600, 13658, 13659, 13660, 13914, 13915, 13916, 13918, 13919, 13920, 14174, 14175, 14176, 14430, 14431, 14432);
+	private static final int PVP_HUB_SYNC_MAX_ATTEMPTS = 5;
+	private static final long PVP_HUB_SYNC_RETRY_DELAY_MILLIS = TimeUnit.MINUTES.toMillis(1);
 
 	static
 	{
@@ -224,7 +227,7 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 	private final Map<Integer, List<HitsplatInfo>> hitsplatBuffer = new HashMap<>();
 	private final Map<Integer, List<HitsplatInfo>> incomingHitsplatsBuffer = new ConcurrentHashMap<>(); // Stores hitsplats *received* by players per tick.
 	private final Map<String, Integer> lastNonGmaulSpecTickByAttacker = new ConcurrentHashMap<>();
-	private final Set<String> pendingPvpHubSyncFightIds = ConcurrentHashMap.newKeySet();
+	private final PvpHubSyncRetryState pendingPvpHubSyncs = new PvpHubSyncRetryState(PVP_HUB_SYNC_MAX_ATTEMPTS, PVP_HUB_SYNC_RETRY_DELAY_MILLIS);
 	private HiscoreEndpoint hiscoreEndpoint = HiscoreEndpoint.NORMAL; // Added field
 	private File pvpHubSyncedFightsDir;
 
@@ -270,7 +273,6 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			.build();
 
 		importFightHistoryData();
-		syncExistingPvpHubFightsOnce();
 		executor.scheduleWithFixedDelay(this::syncPendingPvpHubFights, 60, 60, TimeUnit.SECONDS);
 
 		// add the panel's nav button depending on config
@@ -367,10 +369,20 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			case "robeHitFilter":
 				recalculateAllRobeHits(true);
 				break;
-			case "uploadFightsToPvpHub":
-			case "hideRsnOnPvpHub":
-				if (panel != null)
-				{
+				case "uploadFightsToPvpHub":
+					if (!config.uploadFightsToPvpHub())
+					{
+						pendingPvpHubSyncs.clear();
+					}
+					if (panel != null)
+					{
+						panel.updatePvpHubHiddenName();
+						panel.updatePopupMenuForPvpHubConfig();
+					}
+					break;
+				case "hideRsnOnPvpHub":
+					if (panel != null)
+					{
 					panel.updatePvpHubHiddenName();
 					panel.updatePopupMenuForPvpHubConfig();
 				}
@@ -1454,23 +1466,6 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 		//panel.enqueueRebuild();
 	}
 
-	private void syncExistingPvpHubFightsOnce()
-	{
-		if (!CONFIG.uploadFightsToPvpHub())
-		{
-			return;
-		}
-
-		for (FightPerformance fight : fightHistory)
-		{
-			attachPvpHubSyncedFight(fight);
-			if (!fight.hasPvpHubSyncedFight() && fight.getFightId() != null && !fight.getFightId().trim().isEmpty())
-			{
-				requestPvpHubSync(fight);
-			}
-		}
-	}
-
 	private void enqueuePvpHubSync(FightPerformance fight)
 	{
 		if (fight == null || fight.getFightId() == null || fight.getFightId().trim().isEmpty() || fight.hasPvpHubSyncedFight())
@@ -1478,26 +1473,36 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			return;
 		}
 
-		pendingPvpHubSyncFightIds.add(fight.getFightId().trim());
+		pendingPvpHubSyncs.enqueue(fight.getFightId(), System.currentTimeMillis());
 	}
 
 	private void syncPendingPvpHubFights()
 	{
-		if (!CONFIG.uploadFightsToPvpHub() || pendingPvpHubSyncFightIds.isEmpty())
+		if (!CONFIG.uploadFightsToPvpHub())
+		{
+			pendingPvpHubSyncs.clear();
+			return;
+		}
+
+		if (pendingPvpHubSyncs.isEmpty())
 		{
 			return;
 		}
 
-		for (String fightId : new ArrayList<>(pendingPvpHubSyncFightIds))
+		long nowMillis = System.currentTimeMillis();
+		for (String fightId : pendingPvpHubSyncs.dueFightIds(nowMillis))
 		{
 			FightPerformance fight = findFightById(fightId);
 			if (fight == null || fight.hasPvpHubSyncedFight())
 			{
-				pendingPvpHubSyncFightIds.remove(fightId);
+				pendingPvpHubSyncs.remove(fightId);
 				continue;
 			}
 
-			requestPvpHubSync(fight);
+			if (pendingPvpHubSyncs.markAttemptStarted(fightId, nowMillis))
+			{
+				requestPvpHubSync(fight);
+			}
 		}
 	}
 
@@ -1534,10 +1539,10 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			{
 				try
 				{
-					PvpHubFightSync.saveSyncedFight(pvpHubSyncedFightsDir, fight.getFightId(), responseJson);
-					fight.setPvpHubSyncedFight(syncedFight);
-					pendingPvpHubSyncFightIds.remove(fight.getFightId());
-				}
+						PvpHubFightSync.saveSyncedFight(pvpHubSyncedFightsDir, fight.getFightId(), responseJson);
+						fight.setPvpHubSyncedFight(syncedFight);
+						pendingPvpHubSyncs.remove(fight.getFightId());
+					}
 				catch (Exception e)
 				{
 					fight.setPvpHubSyncInProgress(false);
@@ -1565,11 +1570,12 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			}
 
 			@Override
-			public void onNotSynced(String reason)
-			{
-				fight.setPvpHubSyncInProgress(false);
-				log.debug("PvP-Hub sync unavailable for fight {}: {}", fight.getFightId(), reason);
-			}
+				public void onNotSynced(String reason)
+				{
+					fight.setPvpHubSyncInProgress(false);
+					pendingPvpHubSyncs.markUnavailable(fight.getFightId());
+					log.debug("PvP-Hub sync unavailable for fight {}: {}", fight.getFightId(), reason);
+				}
 		});
 	}
 

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubSyncRetryState.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpHubSyncRetryState.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, LogicalSolutions <https://github.com/LogicalSolutions>
+ * Copyright (c) 2026, Matsyir <https://github.com/Matsyir>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package matsyir.pvpperformancetracker.controllers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class PvpHubSyncRetryState
+{
+	private final int maxAttempts;
+	private final long retryDelayMillis;
+	private final Map<String, PendingSync> pending = new ConcurrentHashMap<>();
+
+	public PvpHubSyncRetryState(int maxAttempts, long retryDelayMillis)
+	{
+		this.maxAttempts = maxAttempts;
+		this.retryDelayMillis = retryDelayMillis;
+	}
+
+	public void enqueue(String fightId, long nowMillis)
+	{
+		String normalizedFightId = normalizeFightId(fightId);
+		if (normalizedFightId == null)
+		{
+			return;
+		}
+
+		pending.computeIfAbsent(normalizedFightId, ignored -> new PendingSync(nowMillis));
+	}
+
+	public boolean isEmpty()
+	{
+		return pending.isEmpty();
+	}
+
+	public List<String> dueFightIds(long nowMillis)
+	{
+		List<String> dueFightIds = new ArrayList<>();
+		for (Map.Entry<String, PendingSync> entry : pending.entrySet())
+		{
+			if (entry.getValue().nextAttemptAtMillis <= nowMillis)
+			{
+				dueFightIds.add(entry.getKey());
+			}
+		}
+		return dueFightIds;
+	}
+
+	public boolean markAttemptStarted(String fightId, long nowMillis)
+	{
+		String normalizedFightId = normalizeFightId(fightId);
+		if (normalizedFightId == null)
+		{
+			return false;
+		}
+
+		PendingSync sync = pending.get(normalizedFightId);
+		if (sync == null)
+		{
+			return false;
+		}
+
+		synchronized (sync)
+		{
+			if (sync.attempts >= maxAttempts || sync.nextAttemptAtMillis > nowMillis)
+			{
+				if (sync.attempts >= maxAttempts)
+				{
+					pending.remove(normalizedFightId);
+				}
+				return false;
+			}
+
+			sync.attempts++;
+			sync.nextAttemptAtMillis = nowMillis + retryDelayMillis;
+			return true;
+		}
+	}
+
+	public void markUnavailable(String fightId)
+	{
+		String normalizedFightId = normalizeFightId(fightId);
+		if (normalizedFightId == null)
+		{
+			return;
+		}
+
+		PendingSync sync = pending.get(normalizedFightId);
+		if (sync == null)
+		{
+			return;
+		}
+
+		synchronized (sync)
+		{
+			if (sync.attempts >= maxAttempts)
+			{
+				pending.remove(normalizedFightId);
+			}
+		}
+	}
+
+	public void remove(String fightId)
+	{
+		String normalizedFightId = normalizeFightId(fightId);
+		if (normalizedFightId != null)
+		{
+			pending.remove(normalizedFightId);
+		}
+	}
+
+	public void clear()
+	{
+		pending.clear();
+	}
+
+	private static String normalizeFightId(String fightId)
+	{
+		if (fightId == null || fightId.trim().isEmpty())
+		{
+			return null;
+		}
+		return fightId.trim();
+	}
+
+	private static final class PendingSync
+	{
+		private int attempts;
+		private long nextAttemptAtMillis;
+
+		private PendingSync(long nextAttemptAtMillis)
+		{
+			this.nextAttemptAtMillis = nextAttemptAtMillis;
+		}
+	}
+}

--- a/src/test/java/matsyir/pvpperformancetracker/controllers/PvpHubSyncRetryStateTest.java
+++ b/src/test/java/matsyir/pvpperformancetracker/controllers/PvpHubSyncRetryStateTest.java
@@ -1,0 +1,73 @@
+package matsyir.pvpperformancetracker.controllers;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PvpHubSyncRetryStateTest
+{
+	@Test
+	public void enqueuedFightIsDueImmediately()
+	{
+		PvpHubSyncRetryState retryState = new PvpHubSyncRetryState(5, 60_000);
+
+		retryState.enqueue(" FIGHT123 ", 1_000);
+
+		assertEquals(1, retryState.dueFightIds(1_000).size());
+		assertEquals("FIGHT123", retryState.dueFightIds(1_000).get(0));
+	}
+
+	@Test
+	public void failedAttemptWaitsForRetryDelay()
+	{
+		PvpHubSyncRetryState retryState = new PvpHubSyncRetryState(5, 60_000);
+		retryState.enqueue("FIGHT123", 1_000);
+
+		assertTrue(retryState.markAttemptStarted("FIGHT123", 1_000));
+		retryState.markUnavailable("FIGHT123");
+
+		assertTrue(retryState.dueFightIds(60_999).isEmpty());
+		assertEquals("FIGHT123", retryState.dueFightIds(61_000).get(0));
+	}
+
+	@Test
+	public void failedAttemptsStopAtMaxAttempts()
+	{
+		PvpHubSyncRetryState retryState = new PvpHubSyncRetryState(2, 60_000);
+		retryState.enqueue("FIGHT123", 1_000);
+
+		assertTrue(retryState.markAttemptStarted("FIGHT123", 1_000));
+		retryState.markUnavailable("FIGHT123");
+		assertFalse(retryState.isEmpty());
+
+		assertTrue(retryState.markAttemptStarted("FIGHT123", 61_000));
+		retryState.markUnavailable("FIGHT123");
+
+		assertTrue(retryState.isEmpty());
+		assertTrue(retryState.dueFightIds(121_000).isEmpty());
+	}
+
+	@Test
+	public void successRemovesPendingFight()
+	{
+		PvpHubSyncRetryState retryState = new PvpHubSyncRetryState(5, 60_000);
+		retryState.enqueue("FIGHT123", 1_000);
+
+		retryState.remove("FIGHT123");
+
+		assertTrue(retryState.isEmpty());
+	}
+
+	@Test
+	public void clearDropsAllPendingFights()
+	{
+		PvpHubSyncRetryState retryState = new PvpHubSyncRetryState(5, 60_000);
+		retryState.enqueue("FIGHT123", 1_000);
+		retryState.enqueue("FIGHT456", 1_000);
+
+		retryState.clear();
+
+		assertTrue(retryState.isEmpty());
+	}
+}


### PR DESCRIPTION
The plugin sync path now avoids the expensive startup sweep for old unsynced fights, and pending PvP-Hub syncs are bounded instead of retrying forever. New uploads still get pull-only sync attempts against /api/fights/{fightId}, but failed “not synced yet” responses now back off and stop after the configured retry cap. Turning PvP-Hub uploads off also clears pending in-session sync work.