### PR TITLE
fix hitsplat matching after delayed attack processing

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -724,7 +724,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			if (currentFight.getOpponent() != null)
 			{
 				totalExpectedAttackHits += currentFight.getOpponent().getPendingAttacks().stream()
-					.filter(e -> !e.isKoChanceCalculated() && e.isFullEntry() && !e.isSplash() && (tickToProcess - e.getTick() <= 5)) // Check if attack could land now
+					.filter(e -> !e.isKoChanceCalculated() && e.isFullEntry() && !e.isSplash() &&
+						(tickToProcess - getHitsplatMatchTick(e) <= Math.max(5, getAttackLookback(e)))) // Check if attack could land now
 					.mapToInt(FightLogEntry::getExpectedHits)
 					.sum();
 			}
@@ -732,7 +733,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			if (currentFight.getCompetitor() != null)
 			{
 				totalExpectedAttackHits += currentFight.getCompetitor().getPendingAttacks().stream()
-					.filter(e -> !e.isKoChanceCalculated() && e.isFullEntry() && !e.isSplash() && (tickToProcess - e.getTick() <= 5)) // Check if attack could land now
+					.filter(e -> !e.isKoChanceCalculated() && e.isFullEntry() && !e.isSplash() &&
+						(tickToProcess - getHitsplatMatchTick(e) <= Math.max(5, getAttackLookback(e)))) // Check if attack could land now
 					.mapToInt(FightLogEntry::getExpectedHits)
 					.sum();
 			}
@@ -904,8 +906,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			// Get all potentially relevant, unprocessed entries sorted by animation tick
 			List<FightLogEntry> candidateEntries = attacker.getPendingAttacks().stream()
 				.filter(e -> !e.isKoChanceCalculated() && e.isFullEntry() && !e.isSplash())
-				.filter(e -> (client.getTickCount() - e.getTick()) <= 5)
-				.sorted(Comparator.comparingInt(FightLogEntry::getTick))
+				.filter(e -> (client.getTickCount() - getHitsplatMatchTick(e)) <= Math.max(5, getAttackLookback(e)))
+				.sorted(Comparator.comparingInt(this::getHitsplatMatchTick).thenComparingInt(FightLogEntry::getTick))
 				.collect(Collectors.toList());
 
 			List<FightLogEntry> gmaulsMatchedThisTick = new ArrayList<>();
@@ -916,14 +918,9 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			{
 
 				// Apply specific lookback for the entry's style
-				int lookback;
-				switch (entry.getAnimationData().attackStyle)
-				{
-					case STAB: case SLASH: case CRUSH: lookback = 3; break;
-					case MAGIC: lookback = 5; break;
-					case RANGED: default: lookback = 3; break;
-				}
-				if (client.getTickCount() - entry.getTick() > lookback)
+				int lookback = getAttackLookback(entry);
+				int hitsplatMatchTick = getHitsplatMatchTick(entry);
+				if (client.getTickCount() - hitsplatMatchTick > lookback)
 				{
 					entry.setKoChanceCalculated(true);
 					attacker.getPendingAttacks().remove(entry);
@@ -938,7 +935,7 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 					continue;
 				}
 
-				boolean isInstantGmaulCheck = entry.isGmaulSpecial() && entry.getTick() == tickToProcess;
+				boolean isInstantGmaulCheck = entry.isGmaulSpecial() && hitsplatMatchTick == tickToProcess;
 				boolean isDelayedAttack = !isInstantGmaulCheck;
 
 				// Only try to match if it's either an instant GMaul or a delayed attack landing now
@@ -966,7 +963,7 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 						if (attackerName != null)
 						{
 							Integer lastSpec = lastNonGmaulSpecTickByAttacker.get(attackerName);
-							if (lastSpec != null && lastSpec == entry.getTick() - 1)
+							if (lastSpec != null && lastSpec == hitsplatMatchTick - 1)
 							{
 								hitsToFind = Math.min(hitsToFind, 1);
 							}
@@ -1276,6 +1273,27 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			return;
 		}
 		lastNonGmaulSpecTickByAttacker.put(attackerName, tick);
+	}
+
+	private int getHitsplatMatchTick(FightLogEntry entry)
+	{
+		return entry.getHitsplatMatchTick() >= 0 ? entry.getHitsplatMatchTick() : entry.getTick();
+	}
+
+	private int getAttackLookback(FightLogEntry entry)
+	{
+		switch (entry.getAnimationData().attackStyle)
+		{
+			case STAB:
+			case SLASH:
+			case CRUSH:
+				return 3;
+			case MAGIC:
+				return 6;
+			case RANGED:
+			default:
+				return 4;
+		}
 	}
 
 	// #################################################################################################################

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/Fighter.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/Fighter.java
@@ -285,7 +285,7 @@ class Fighter
 		fightLogEntry.setGmaulSpecial(isGmaulSpec);
 		if (animationData.isSpecial && animationData != AnimationData.MELEE_GRANITE_MAUL_SPEC)
 		{
-			PvpPerformanceTrackerPlugin.PLUGIN.recordNonGmaulSpecial(player.getName(), fightLogEntry.getTick());
+			PvpPerformanceTrackerPlugin.PLUGIN.recordNonGmaulSpecial(player.getName(), fightLogEntry.getHitsplatMatchTick());
 		}
 		if (PvpPerformanceTrackerPlugin.CONFIG.fightLogInChat())
 		{

--- a/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
@@ -191,6 +191,9 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 	@Getter
 	@Setter
 	private int hitsplatTick = -1;
+	@Getter
+	@Setter
+	private transient int hitsplatMatchTick = -1;
 
 	// Display/Transient fields calculated during post-processing in onGameTick
 	@Expose
@@ -246,6 +249,7 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 		this.attackerName = attacker.getName();
 		this.time = time;
 		this.tick = tick;
+		this.hitsplatMatchTick = PLUGIN.getClient().getTickCount();
 
 		this.animationData = animationData;
 
@@ -287,6 +291,7 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 		this.attackerName = attackerName;
 		this.time = time;
 		this.tick = tick;
+		this.hitsplatMatchTick = PLUGIN.getClient().getTickCount();
 
 		this.attackerLevels = levels;
 		this.attackerOffensivePray = attackerOffensivePray;
@@ -304,6 +309,7 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 		this.attackerName = e.attackerName;
 		this.time = e.time;
 		this.tick = e.tick;
+		this.hitsplatMatchTick = e.hitsplatMatchTick;
 
 		// attacker data
 		this.attackerGear = e.attackerGear;

--- a/src/main/java/matsyir/pvpperformancetracker/views/FightLogFrame.java
+++ b/src/main/java/matsyir/pvpperformancetracker/views/FightLogFrame.java
@@ -210,11 +210,13 @@ public class FightLogFrame extends JFrame
 				int splashIcon = SpriteID.SPELL_ICE_BARRAGE_DISABLED;
 				PLUGIN.addSpriteToLabelIfValid(dmgLabel, splashIcon, this::repaint);
 			}
+			else if (fightEntry.getMatchedHitsCount() <= 0)
+			{
+				dmgLabel.setText("?");
+			}
 			else
 			{
-				Integer actualDmg = fightEntry.getActualDamageSum();
-				String dmgText = actualDmg != null ? nf.format(actualDmg) : "-";
-				dmgLabel.setText(dmgText);
+				dmgLabel.setText(nf.format(fightEntry.getActualDamageSum()));
 			}
 			stats[i][COLIDX_DMG_DEALT] = dmgLabel;
 			// HP column - Display as Current/Max


### PR DESCRIPTION
I figured out the gmaul matching issue came from 96686b5 which keeps the original animation tick on fight log entries created inside the delayed invokeLater callback.

That was good for log/sync timing, but live hitsplat matching also used that tick. For instant gmauls, the entry could be created a tick later while still looking one tick older, so the instant hitsplat check could miss it.

Showing `?` instead of 0 for unmatched attacks in the actual dmg column also showed that some slower range/mage hits were falling just outside their match window, so I widened those by one tick too.