### PR TITLE
Correct one-sided POV (local) fights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PvP Performance Tracker (v1.8.5)
+# PvP Performance Tracker (v1.8.6)
 [![Active Installs](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/pvp-performance-tracker)](https://runelite.net/plugin-hub/Matsyir) [![Plugin Rank](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/pvp-performance-tracker)](https://runelite.net/plugin-hub)
 
 [_View patch notes & version history_](https://github.com/Matsyir/pvp-performance-tracker/wiki#version-history--patch-notes)

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'matsyir.pvpperformancetracker'
-version = '1.8.5'
+version = '1.8.6'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerConfig.java
@@ -811,7 +811,7 @@ public interface PvpPerformanceTrackerConfig extends Config
 
 	// ================================= On-update flags for chat message update summaries =================================
 	// to avoid spamming multiple update messages for a user who was inactive, just use and overwrite one at a time.
-	String updateMsgKey = "updateMsgShown1_8_5";
+	String updateMsgKey = "updateMsgShown1_8_6";
 	@ConfigItem(
 		keyName = updateMsgKey,
 		name = "Update Msg flag for most recent update",
@@ -825,6 +825,7 @@ public interface PvpPerformanceTrackerConfig extends Config
 
 	// throw any updateMsgShown keys into this as we change it. Or any other config we won't be using anymore.
 	public static final String[] UPDATE_MSG_KEY_GRAVEYARD = {
+		"updateMsgShown1_8_5",
 		"updateMsgShown1_8_4",
 		"updateMsgShown1_8_3",
 		"updateMsgShown1_8_2",

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -131,7 +131,7 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 
 	// reminder: the version number update is needed in a few different places.
 	// Run a find-all of the old version number before updating version.
-	public static final String PLUGIN_VERSION = "1.8.5";
+	public static final String PLUGIN_VERSION = "1.8.6";
 	public static final String CONFIG_KEY = "pvpperformancetracker";
 	// Data folder naming history:
 	// "pvp-performance-tracker": From release, until 1.5.9 update @ 2024-08-19
@@ -636,6 +636,11 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 		Skill skill = statChanged.getSkill();
 		if (!hasOpponent()) { return; }
 
+		if (isCombatBoostSkill(skill))
+		{
+			currentFight.refreshCompetitorLevelsForTick(client.getTickCount(), new CombatLevels(client));
+		}
+
 		if (skill == Skill.HITPOINTS)
 		{
 			currentFight.updateCompetitorHp(client.getBoostedSkillLevel(Skill.HITPOINTS));
@@ -650,6 +655,15 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 				clientThread.invokeLater(this::checkForGhostBarrage);
 			}
 		}
+	}
+
+	private static boolean isCombatBoostSkill(Skill skill)
+	{
+		return skill == Skill.ATTACK
+			|| skill == Skill.STRENGTH
+			|| skill == Skill.DEFENCE
+			|| skill == Skill.RANGED
+			|| skill == Skill.MAGIC;
 	}
 
 	@Subscribe
@@ -1786,8 +1800,10 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 		return client.isPrayerActive(Prayer.PIETY) 				? SpriteID.PRAYER_PIETY :
 				client.isPrayerActive(Prayer.ULTIMATE_STRENGTH) ? SpriteID.PRAYER_ULTIMATE_STRENGTH :
 				client.isPrayerActive(Prayer.RIGOUR) 			? SpriteID.PRAYER_RIGOUR :
+				client.isPrayerActive(Prayer.DEADEYE) 			? SpriteID.PRAYER_DEADEYE :
 				client.isPrayerActive(Prayer.EAGLE_EYE) 		? SpriteID.PRAYER_EAGLE_EYE :
 				client.isPrayerActive(Prayer.AUGURY) 			? SpriteID.PRAYER_AUGURY :
+				client.isPrayerActive(Prayer.MYSTIC_VIGOUR)		? SpriteID.PRAYER_MYSTIC_VIGOUR :
 				client.isPrayerActive(Prayer.MYSTIC_MIGHT)		? SpriteID.PRAYER_MYSTIC_MIGHT :
 				0;
 	}

--- a/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
+++ b/src/main/java/matsyir/pvpperformancetracker/PvpPerformanceTrackerPlugin.java
@@ -1326,7 +1326,7 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 		// don't directly use PLUGIN_VERSION in the prefix because there may be times we don't include a new update
 		// message and want it to remain the same as the previous version. For example, if there's a small hotfix after a major update.
 		// There should be intent behind the version number shown in the update message, not just automatically showing the current version.
-		String updateMsgForVersion = "1.8.5";
+		String updateMsgForVersion = "1.8.6";
 		String updatePrefix = "<shad=000000><col=" + ColorUtil.colorToHexCode(PvpColorScheme.BLOOD_RED_ORANGE) +
 			">PvP Performance Tracker</col> <col=" + ColorUtil.colorToHexCode(PvpColorScheme.BLOOD_RED_ORANGE_REDDER) +
 			"><u>v" + updateMsgForVersion + "</u></col> <col=" + ColorUtil.colorToHexCode(PvpColorScheme.BLOOD_RED_ORANGE) +
@@ -1335,8 +1335,8 @@ public class PvpPerformanceTrackerPlugin extends Plugin
 			.type(ChatMessageType.GAMEMESSAGE)
 			.runeLiteFormattedMessage(updatePrefix +
 				"<col=" + ColorUtil.colorToHexCode(PvpColorScheme.DARK_ORANGE_BROWN_TEXT) + ">" +
-				"Augury now properly applies +4% mage damage boost. Support for Virtus set hidden damage boost on ancients, +3% damage per piece. " +
-				"Improved reliability when fetching synced fights from PvP-Hub. Minor tooltip clarifications.")
+				"Single-side POV fights now assume your opponent is using the proper offensive and defensive prayers throughout the fight. " +
+				"Possibly corrected incorrect stats for same-tick restore attacks.")
 				.build());
 
 		configManager.setConfiguration(CONFIG_KEY, PvpPerformanceTrackerConfig.updateMsgKey, true);

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
@@ -40,6 +40,7 @@ import static matsyir.pvpperformancetracker.PvpPerformanceTrackerPlugin.CONFIG;
 import static matsyir.pvpperformancetracker.PvpPerformanceTrackerPlugin.PLUGIN;
 import matsyir.pvpperformancetracker.models.AnimationData;
 import matsyir.pvpperformancetracker.models.AnimationData.AttackStyle;
+import matsyir.pvpperformancetracker.models.AssumedPrayers;
 import matsyir.pvpperformancetracker.models.CombatLevels;
 import matsyir.pvpperformancetracker.models.FightLogEntry;
 import matsyir.pvpperformancetracker.models.FightType;
@@ -216,8 +217,11 @@ public class FightPerformance implements Comparable<FightPerformance>
 		{
 			recordInitialFightTick(animationTick);
 			opponent.setPlayer(eventSource);
-			// there is no offensive prayer data for the opponent so hardcode 0
-			opponent.addAttack(competitor.getPlayer(), animationData, 0, null, animationTick, animationTime);
+			// Opponent prayers aren't visible; assume they match local prayer unlocks for the attack style.
+			int assumedOffensivePray = AssumedPrayers.assumedOffensivePray(
+				animationData.attackStyle,
+				AssumedPrayers.localPrayerLevel(PLUGIN.getClient()));
+			opponent.addAttack(competitor.getPlayer(), animationData, assumedOffensivePray, null, animationTick, animationTime);
 			addedAttack = true;
 			// add a defensive log for the competitor while the opponent is attacking, to be used with the fight analysis/merge
 			competitor.addDefensiveLogs(competitorLevels, PLUGIN.currentlyUsedOffensivePray(), animationTick, animationTime);
@@ -325,6 +329,11 @@ public class FightPerformance implements Comparable<FightPerformance>
 			competitor.addHpHealed(hpHealed);
 		}
 		competitorPrevHp = currentHp;
+	}
+
+	public void refreshCompetitorLevelsForTick(int tick, CombatLevels levels)
+	{
+		competitor.refreshCombatLevelsForTick(tick, levels);
 	}
 
 	// Will return true if either competitor has died yet

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/Fighter.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/Fighter.java
@@ -371,6 +371,39 @@ class Fighter
 		fightLogEntries.add(new FightLogEntry(name, levels, offensivePray, attackTick, attackTime));
 	}
 
+	void refreshCombatLevelsForTick(int tick, CombatLevels levels)
+	{
+		refreshCombatLevelsForTick(fightLogEntries, tick, levels);
+	}
+
+	static void refreshCombatLevelsForTick(ArrayList<FightLogEntry> entries, int tick, CombatLevels levels)
+	{
+		if (entries == null || levels == null)
+		{
+			return;
+		}
+
+		for (int i = entries.size() - 1; i >= 0; i--)
+		{
+			FightLogEntry entry = entries.get(i);
+			if (entry.getTick() < tick)
+			{
+				break;
+			}
+			if (entry.getTick() > tick || entry.getAttackerLevels() == null)
+			{
+				continue;
+			}
+
+			entry.setAttackerLevels(copyLevels(levels));
+		}
+	}
+
+	private static CombatLevels copyLevels(CombatLevels levels)
+	{
+		return new CombatLevels(levels.atk, levels.str, levels.def, levels.range, levels.mage, levels.hp);
+	}
+
 	// Return a simple string to display the current player's success rate.
 	// ex. "42/59 (71%)". The name is not included as it will be in a separate view.
 	// if shortString is true, the percentage is omitted, it only returns the fraction.

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
@@ -39,7 +39,9 @@ import static matsyir.pvpperformancetracker.utils.PvpUtils.fixItemId;
 import static matsyir.pvpperformancetracker.utils.PvpUtils.getExpectedHits;
 import matsyir.pvpperformancetracker.models.EquipmentData;
 import matsyir.pvpperformancetracker.models.EquipmentData.VoidStyle;
+import matsyir.pvpperformancetracker.models.AssumedPrayers;
 import matsyir.pvpperformancetracker.models.CombatLevels;
+import net.runelite.api.Skill;
 import matsyir.pvpperformancetracker.models.RangeAmmoData;
 import matsyir.pvpperformancetracker.models.RingData;
 import net.runelite.api.EquipmentInventorySlot;
@@ -87,15 +89,19 @@ public class PvpDamageCalc
 	private static final double AUGURY_OFFENSIVE_PRAYER_MODIFIER = 1.25;
 	private static final double AUGURY_OFFENSIVE_PRAYER_DMG_MODIFIER = 1.04;
 	private static final double MYSTIC_MIGHT_PRAYER_MODIFIER = 1.15;
+	private static final double MYSTIC_VIGOUR_PRAYER_MODIFIER = 1.18;
+	private static final double MYSTIC_VIGOUR_OFFENSIVE_PRAYER_DMG_MODIFIER = 1.03;
 	private static final double RIGOUR_OFFENSIVE_PRAYER_DMG_MODIFIER = 1.23;
 	private static final double RIGOUR_OFFENSIVE_PRAYER_ATTACK_MODIFIER = 1.2;
 	private static final double EAGLE_EYE_PRAYER_MODIFIER = 1.15;
+	private static final double DEADEYE_PRAYER_MODIFIER = 1.18;
 
-	// Defensive pray: Assume you have one of the defensive prays active, but don't assume you have augury
-	// while getting maged, since you would likely be planning to range or melee & using rigour/piety instead.
+	// Defensive pray: live tracking assumes Piety/Rigour/Augury (25%) when the local prayer
+	// level unlocks them; otherwise Steel Skin (15%). Augury mage-def only when Augury is unlocked.
+	// Merge path still uses high-tier def + defender-log Augury when available.
 	private static final double PIETY_DEF_PRAYER_MODIFIER = 1.25;
 	private static final double AUGURY_DEF_PRAYER_MODIFIER = 1.25;
-	private static final double AUGURY_MAGEDEF_PRAYER_MODIFIER = 1.25; // assume we never use augury during defence for now (unless merging stats).
+	private static final double AUGURY_MAGEDEF_PRAYER_MODIFIER = 1.25;
 	private static final double RIGOUR_DEF_PRAYER_MODIFIER = 1.25;
 
 	private static final double BALLISTA_SPEC_ACCURACY_MODIFIER = 1.25;
@@ -142,6 +148,7 @@ public class PvpDamageCalc
 	public static final double SMOKE_BATTLESTAFF_DMG_ACC_MODIFIER = 1.1; // both dmg & accuracy modifier
 	public static final double TOME_OF_FIRE_DMG_MODIFIER = 1.5;
 	public static final double VOLATILE_NIGHTMARE_STAFF_ACC_MODIFIER = 0.5;
+	private static final int VIRTUS_ANCIENT_MAGIC_DMG_BONUS = 3;
 
 
 	@Getter
@@ -205,15 +212,20 @@ public class PvpDamageCalc
 		boolean isSpecial = animationData.isSpecial;
 		VoidStyle voidStyle = VoidStyle.getVoidStyleFor(attacker.getPlayerComposition().getEquipmentIds());
 
+		// Assume defender prayers match local prayer unlocks (opponent prayers are not visible).
+		int localPrayerLevel = PLUGIN.getClient().getRealSkillLevel(Skill.PRAYER);
+		double defencePrayerModifier = AssumedPrayers.assumedDefencePrayerModifier(attackStyle, localPrayerLevel);
+		boolean defensiveAugurySuccess = AssumedPrayers.assumedDefensiveAugury(localPrayerLevel);
+
 		if (attackStyle.isMelee() || animationData == AnimationData.MELEE_VOIDWAKER_SPEC)
 		{
 			getMeleeMaxHit(playerStats[STRENGTH_BONUS], isSpecial, weapon, voidStyle, offensivePray);
-			getMeleeAccuracy(playerStats, opponentStats, attackStyle, isSpecial, weapon, voidStyle, offensivePray);
+			getMeleeAccuracy(playerStats, opponentStats, attackStyle, isSpecial, weapon, voidStyle, offensivePray, defencePrayerModifier);
 		}
 		else if (attackStyle == AttackStyle.RANGED)
 		{
 			getRangedMaxHit(playerStats[RANGE_STRENGTH], isSpecial, weapon, voidStyle, offensivePray, attackerItems, animationData, attackerAmmoItemId);
-			getRangeAccuracy(playerStats[RANGE_ATTACK], opponentStats[RANGE_DEF], isSpecial, weapon, voidStyle, offensivePray, attackerItems, attackerAmmoItemId);
+			getRangeAccuracy(playerStats[RANGE_ATTACK], opponentStats[RANGE_DEF], isSpecial, weapon, voidStyle, offensivePray, attackerItems, attackerAmmoItemId, defencePrayerModifier);
 		}
 		// this should always be true at this point, but just in case. unknown animation styles won't
 		// make it here, they should be stopped in FightPerformance::checkForAttackAnimations
@@ -224,7 +236,7 @@ public class PvpDamageCalc
 			EquipmentData top = EquipmentData.fromId(fixItemId(attackerItems[KitType.TORSO.getIndex()]));
 			EquipmentData bottom = EquipmentData.fromId(fixItemId(attackerItems[KitType.LEGS.getIndex()]));
 			getMagicMaxHit(playerStats[MAGIC_DAMAGE], animationData, offensivePray, voidStyle, shield, weapon, hat, top, bottom);
-			getMagicAccuracy(playerStats[MAGIC_ATTACK], opponentStats[MAGIC_DEF], weapon, animationData, voidStyle, offensivePray, false);
+			getMagicAccuracy(playerStats[MAGIC_ATTACK], opponentStats[MAGIC_DEF], weapon, animationData, voidStyle, offensivePray, defensiveAugurySuccess, defencePrayerModifier);
 		}
 
 		getAverageHit(success, weapon, isSpecial);
@@ -270,12 +282,12 @@ public class PvpDamageCalc
 		if (attackStyle.isMelee())
 		{
 			getMeleeMaxHit(playerStats[STRENGTH_BONUS], isSpecial, weapon, voidStyle, offensivePray);
-			getMeleeAccuracy(playerStats, opponentStats, attackStyle, isSpecial, weapon, voidStyle, offensivePray);
+			getMeleeAccuracy(playerStats, opponentStats, attackStyle, isSpecial, weapon, voidStyle, offensivePray, PIETY_DEF_PRAYER_MODIFIER);
 		}
 		else if (attackStyle == AttackStyle.RANGED)
 		{
 			getRangedMaxHit(playerStats[RANGE_STRENGTH], isSpecial, weapon, voidStyle, offensivePray, attackerItems, animationData, attackerAmmoItemId);
-			getRangeAccuracy(playerStats[RANGE_ATTACK], opponentStats[RANGE_DEF], isSpecial, weapon, voidStyle, offensivePray, attackerItems, attackerAmmoItemId);
+			getRangeAccuracy(playerStats[RANGE_ATTACK], opponentStats[RANGE_DEF], isSpecial, weapon, voidStyle, offensivePray, attackerItems, attackerAmmoItemId, RIGOUR_DEF_PRAYER_MODIFIER);
 		}
 		// this should always be true at this point, but just in case. unknown animation styles won't
 		// make it here, they should be stopped in FightPerformance::checkForAttackAnimations
@@ -286,7 +298,8 @@ public class PvpDamageCalc
 			EquipmentData top = EquipmentData.fromId(fixItemId(attackerItems[KitType.TORSO.getIndex()]));
 			EquipmentData bottom = EquipmentData.fromId(fixItemId(attackerItems[KitType.LEGS.getIndex()]));
 			getMagicMaxHit(playerStats[MAGIC_DAMAGE], animationData, offensivePray, voidStyle, shield, weapon, hat, top, bottom);
-			getMagicAccuracy(playerStats[MAGIC_ATTACK], opponentStats[MAGIC_DEF], weapon, animationData, voidStyle, offensivePray, defenderLog.getAttackerOffensivePray() == SpriteID.PRAYER_AUGURY);
+			getMagicAccuracy(playerStats[MAGIC_ATTACK], opponentStats[MAGIC_DEF], weapon, animationData, voidStyle, offensivePray,
+				defenderLog.getAttackerOffensivePray() == SpriteID.PRAYER_AUGURY, AUGURY_DEF_PRAYER_MODIFIER);
 		}
 
 		getAverageHit(success, weapon, isSpecial);
@@ -539,6 +552,7 @@ public class PvpDamageCalc
 	private double getRangedDamagePrayerModifier(int offensivePray)
 	{
 		return offensivePray == SpriteID.PRAYER_RIGOUR ? RIGOUR_OFFENSIVE_PRAYER_DMG_MODIFIER :
+			offensivePray == SpriteID.PRAYER_DEADEYE ? DEADEYE_PRAYER_MODIFIER :
 			offensivePray == SpriteID.PRAYER_EAGLE_EYE ? EAGLE_EYE_PRAYER_MODIFIER :
 			1;
 	}
@@ -546,18 +560,22 @@ public class PvpDamageCalc
 	private double getRangedAttackPrayerModifier(int offensivePray)
 	{
 		return offensivePray == SpriteID.PRAYER_RIGOUR ? RIGOUR_OFFENSIVE_PRAYER_ATTACK_MODIFIER :
+			offensivePray == SpriteID.PRAYER_DEADEYE ? DEADEYE_PRAYER_MODIFIER :
 			offensivePray == SpriteID.PRAYER_EAGLE_EYE ? EAGLE_EYE_PRAYER_MODIFIER :
 			1;
 	}
 
 	private double getMagicDamagePrayerModifier(int offensivePray)
 	{
-		return offensivePray == SpriteID.PRAYER_AUGURY ? AUGURY_OFFENSIVE_PRAYER_DMG_MODIFIER : 1;
+		return offensivePray == SpriteID.PRAYER_AUGURY ? AUGURY_OFFENSIVE_PRAYER_DMG_MODIFIER :
+			offensivePray == SpriteID.PRAYER_MYSTIC_VIGOUR ? MYSTIC_VIGOUR_OFFENSIVE_PRAYER_DMG_MODIFIER :
+			1;
 	}
 
 	private double getMagicAttackPrayerModifier(int offensivePray)
 	{
 		return offensivePray == SpriteID.PRAYER_AUGURY ? AUGURY_OFFENSIVE_PRAYER_MODIFIER :
+			offensivePray == SpriteID.PRAYER_MYSTIC_VIGOUR ? MYSTIC_VIGOUR_PRAYER_MODIFIER :
 			offensivePray == SpriteID.PRAYER_MYSTIC_MIGHT ? MYSTIC_MIGHT_PRAYER_MODIFIER :
 			1;
 	}
@@ -770,9 +788,9 @@ public class PvpDamageCalc
 		boolean tome = shield == EquipmentData.TOME_OF_FIRE;
 
 		// assume use of ancients if wearing virtus and apply the hidden +3% per piece
-		mageDamageBonus += hat == EquipmentData.VIRTUS_MASK ? 3 : 0;
-		mageDamageBonus += top == EquipmentData.VIRTUS_ROBE_TOP ? 3 : 0;
-		mageDamageBonus += bottom == EquipmentData.VIRTUS_ROBE_BOTTOM ? 3 : 0;
+		mageDamageBonus += hat == EquipmentData.VIRTUS_MASK ? VIRTUS_ANCIENT_MAGIC_DMG_BONUS : 0;
+		mageDamageBonus += top == EquipmentData.VIRTUS_ROBE_TOP ? VIRTUS_ANCIENT_MAGIC_DMG_BONUS : 0;
+		mageDamageBonus += bottom == EquipmentData.VIRTUS_ROBE_BOTTOM ? VIRTUS_ANCIENT_MAGIC_DMG_BONUS : 0;
 
 		double magicBonus = 1 + (mageDamageBonus / 100.0);
 		magicBonus *= getMagicDamagePrayerModifier(offensivePray);
@@ -795,7 +813,7 @@ public class PvpDamageCalc
 		maxHit = (int)(animationData.baseSpellDamage * magicBonus);
 	}
 
-	private void getMeleeAccuracy(int[] playerStats, int[] opponentStats, AttackStyle attackStyle, boolean usingSpec, EquipmentData weapon, VoidStyle voidStyle, int offensivePray)
+	private void getMeleeAccuracy(int[] playerStats, int[] opponentStats, AttackStyle attackStyle, boolean usingSpec, EquipmentData weapon, VoidStyle voidStyle, int offensivePray, double defencePrayerModifier)
 	{
 		boolean vls = weapon == EquipmentData.VESTAS_LONGSWORD;
 		boolean ags = weapon == EquipmentData.ARMADYL_GODSWORD;
@@ -871,7 +889,7 @@ public class PvpDamageCalc
 		/**
 		 * Defender Chance
 		 */
-		effectiveLevelTarget = Math.floor(((defenderLevels.def * PIETY_DEF_PRAYER_MODIFIER) + STANCE_BONUS) + 8);
+		effectiveLevelTarget = Math.floor(((defenderLevels.def * defencePrayerModifier) + STANCE_BONUS) + 8);
 
 		if (vls && usingSpec)
 		{
@@ -895,7 +913,7 @@ public class PvpDamageCalc
 		}
 	}
 
-	private void getRangeAccuracy(int playerRangeAtt, int opponentRangeDef, boolean usingSpec, EquipmentData weapon, VoidStyle voidStyle, int offensivePray, int[] attackerComposition, Integer attackerAmmoItemId)
+	private void getRangeAccuracy(int playerRangeAtt, int opponentRangeDef, boolean usingSpec, EquipmentData weapon, VoidStyle voidStyle, int offensivePray, int[] attackerComposition, Integer attackerAmmoItemId, double defencePrayerModifier)
 	{
 		RangeAmmoData weaponAmmo = getWeaponAmmo(weapon, attackerAmmoItemId);
 		playerRangeAtt += RangeAmmoData.getSeekingArrowAccuracyBonus(weaponAmmo, this.isLmsFight);
@@ -958,7 +976,7 @@ public class PvpDamageCalc
 		/**
 		 * Defender Chance
 		 */
-		effectiveLevelTarget = Math.floor(((defenderLevels.def * RIGOUR_DEF_PRAYER_MODIFIER) + STANCE_BONUS) + 8);
+		effectiveLevelTarget = Math.floor(((defenderLevels.def * defencePrayerModifier) + STANCE_BONUS) + 8);
 		defenderChance = Math.floor(effectiveLevelTarget * ((double) opponentRangeDef + 64));
 
 		/**
@@ -983,7 +1001,7 @@ public class PvpDamageCalc
 		accuracy = (diamonds || opals) && !(dragonCbow && usingSpec) ? (accuracy * .95) + .05 : accuracy;
 	}
 
-	private void getMagicAccuracy(int playerMageAtt, int opponentMageDef, EquipmentData weapon, AnimationData animationData, VoidStyle voidStyle, int offensivePray, boolean defensiveAugurySuccess)
+	private void getMagicAccuracy(int playerMageAtt, int opponentMageDef, EquipmentData weapon, AnimationData animationData, VoidStyle voidStyle, int offensivePray, boolean defensiveAugurySuccess, double defencePrayerModifier)
 	{
 		double effectiveLevelPlayer;
 
@@ -1014,7 +1032,7 @@ public class PvpDamageCalc
 		/**
 		 * Defender Chance
 		 */
-		effectiveLevelTarget = Math.floor(((defenderLevels.def * AUGURY_DEF_PRAYER_MODIFIER) + STANCE_BONUS) + 8);
+		effectiveLevelTarget = Math.floor(((defenderLevels.def * defencePrayerModifier) + STANCE_BONUS) + 8);
 		effectiveMagicLevelTarget = Math.floor((defenderLevels.mage * (defensiveAugurySuccess ? AUGURY_MAGEDEF_PRAYER_MODIFIER : 1)) * 0.70);
 		reducedDefenceLevelTarget = Math.floor(effectiveLevelTarget * 0.30);
 		effectiveMagicDefenceTarget = effectiveMagicLevelTarget + reducedDefenceLevelTarget;

--- a/src/main/java/matsyir/pvpperformancetracker/models/AnimationData.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/AnimationData.java
@@ -296,9 +296,11 @@ public enum AnimationData
 					 pray == SpriteID.PRAYER_ULTIMATE_STRENGTH)) ||
 				(this == RANGED &&
 					(pray == SpriteID.PRAYER_RIGOUR ||
+					 pray == SpriteID.PRAYER_DEADEYE ||
 					 pray == SpriteID.PRAYER_EAGLE_EYE)) ||
 				(this == MAGIC &&
 					(pray == SpriteID.PRAYER_AUGURY ||
+					 pray == SpriteID.PRAYER_MYSTIC_VIGOUR ||
 					 pray == SpriteID.PRAYER_MYSTIC_MIGHT)))
 			);
 		}

--- a/src/main/java/matsyir/pvpperformancetracker/models/AssumedPrayers.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/AssumedPrayers.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, LogicalSolutions <https://github.com/LogicalSoIutions>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package matsyir.pvpperformancetracker.models;
+
+import matsyir.pvpperformancetracker.models.AnimationData.AttackStyle;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import net.runelite.api.SpriteID;
+
+/**
+ * Opponent prayer assumptions for local (unsynced) tracking.
+ * RuneLite cannot see another player's prayers, so we assume they match the
+ * local player's prayer unlocks based on the local real Prayer level.
+ */
+public final class AssumedPrayers
+{
+	public static final int PIETY_LEVEL = 70;
+	public static final int RIGOUR_LEVEL = 74;
+	public static final int AUGURY_LEVEL = 77;
+
+	/** Steel Skin / equivalent 15% Defence prayer. */
+	public static final double STEEL_SKIN_DEF_PRAYER_MODIFIER = 1.15;
+
+	private AssumedPrayers()
+	{
+	}
+
+	public static int localPrayerLevel(Client client)
+	{
+		return client.getRealSkillLevel(Skill.PRAYER);
+	}
+
+	/**
+	 * Assumed offensive prayer sprite for an opponent attack of the given style.
+	 */
+	public static int assumedOffensivePray(AttackStyle attackStyle, int prayerLevel)
+	{
+		if (attackStyle == null)
+		{
+			return 0;
+		}
+
+		if (attackStyle.isMelee())
+		{
+			return prayerLevel >= PIETY_LEVEL
+				? SpriteID.PRAYER_PIETY
+				: SpriteID.PRAYER_ULTIMATE_STRENGTH;
+		}
+		if (attackStyle == AttackStyle.RANGED)
+		{
+			return prayerLevel >= RIGOUR_LEVEL
+				? SpriteID.PRAYER_RIGOUR
+				: SpriteID.PRAYER_DEADEYE;
+		}
+		if (attackStyle == AttackStyle.MAGIC)
+		{
+			return prayerLevel >= AUGURY_LEVEL
+				? SpriteID.PRAYER_AUGURY
+				: SpriteID.PRAYER_MYSTIC_VIGOUR;
+		}
+		return 0;
+	}
+
+	/**
+	 * Defence-level prayer modifier for the defender against an incoming attack style.
+	 * High unlocks use Piety/Rigour/Augury (25%); otherwise Steel Skin (15%).
+	 */
+	public static double assumedDefencePrayerModifier(AttackStyle incomingAttackStyle, int prayerLevel)
+	{
+		if (incomingAttackStyle == null)
+		{
+			return STEEL_SKIN_DEF_PRAYER_MODIFIER;
+		}
+
+		if (incomingAttackStyle.isMelee())
+		{
+			return prayerLevel >= PIETY_LEVEL ? 1.25 : STEEL_SKIN_DEF_PRAYER_MODIFIER;
+		}
+		if (incomingAttackStyle == AttackStyle.RANGED)
+		{
+			return prayerLevel >= RIGOUR_LEVEL ? 1.25 : STEEL_SKIN_DEF_PRAYER_MODIFIER;
+		}
+		if (incomingAttackStyle == AttackStyle.MAGIC)
+		{
+			return prayerLevel >= AUGURY_LEVEL ? 1.25 : STEEL_SKIN_DEF_PRAYER_MODIFIER;
+		}
+		return STEEL_SKIN_DEF_PRAYER_MODIFIER;
+	}
+
+	/** Whether Augury's Magic Defence bonus should be assumed while defending. */
+	public static boolean assumedDefensiveAugury(int prayerLevel)
+	{
+		return prayerLevel >= AUGURY_LEVEL;
+	}
+}

--- a/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
+++ b/src/main/java/matsyir/pvpperformancetracker/models/FightLogEntry.java
@@ -108,6 +108,7 @@ public class FightLogEntry implements Comparable<FightLogEntry>
 	private boolean splash; // true if it was a magic attack and it splashed
 	@Expose
 	@SerializedName("C")
+	@Setter
 	private CombatLevels attackerLevels; // CAN BE NULL
 
 	@Getter

--- a/src/main/java/matsyir/pvpperformancetracker/views/FightLogDetailFrame.java
+++ b/src/main/java/matsyir/pvpperformancetracker/views/FightLogDetailFrame.java
@@ -196,8 +196,9 @@ class FightLogDetailFrame extends JFrame
 		// if there's a valid offensive pray, display it.
 		PLUGIN.addSpriteToLabelIfValid(attackerOffensiveLabel, logEntry.getAttackerOffensivePray());
 
-		if (!isCompetitorLog) // if it wasn't a competitor log, then this is N/A in most cases, and
-		{ // do NOT put a bank filler, to indicate that this is fully N/A, and not "None"
+		// Opponent prayers are assumed from local prayer unlocks when unsynced; only show N/A if none was stored.
+		if (!isCompetitorLog && logEntry.getAttackerOffensivePray() <= 0)
+		{
 			attackerOffensiveLabel.setText("N/A");
 			attackerOffensiveLabel.setIcon(null);
 		}
@@ -331,9 +332,11 @@ class FightLogDetailFrame extends JFrame
 				"<br>The Levels shown here are the Levels that were used for the Expected Damage (eD) calculation, which" +
 				"<br>assumes both players are always potted, in order to be as fair as possible for both players. These" +
 				"<br>Levels are pulled from your config outside of LMS, and are hardcoded to potted LMS stats inside of LMS." +
-				"<br><br>Offensive prayers are also assumed to always be correct while attacking," +
-				"<br>and assumed to be piety or rigour while defending (for both players)." +
-				"<br><br>This has always been the case." +
+				"<br><br>Opponent offensive prayers are assumed to match your Prayer unlocks for their attack style" +
+				"<br>(Piety/Rigour/Augury, or Ultimate Strength/Deadeye/Mystic Vigour below those levels)." +
+				"<br>While defending, Piety/Rigour/Augury (25% Defence) are assumed when unlocked; otherwise Steel Skin (15%)." +
+				"<br>Augury Magic Defence is assumed only when your Prayer level unlocks Augury." +
+				"<br><br>These assumptions are used for Expected Damage until the fight is merged/synced." +
 				"<br><u>You can toggle the visibility of this warning by right clicking it.</u>";
 			JPopupMenu warningTogglePopupMenu = new JPopupMenu();
 			JMenuItem warningToggleMenuItem = new JMenuItem("Toggle Warning Visibility");

--- a/src/test/java/matsyir/pvpperformancetracker/controllers/FighterRefreshCombatLevelsTest.java
+++ b/src/test/java/matsyir/pvpperformancetracker/controllers/FighterRefreshCombatLevelsTest.java
@@ -1,0 +1,38 @@
+package matsyir.pvpperformancetracker.controllers;
+
+import java.util.ArrayList;
+import matsyir.pvpperformancetracker.models.CombatLevels;
+import matsyir.pvpperformancetracker.models.FightLogEntry;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class FighterRefreshCombatLevelsTest
+{
+	@Test
+	public void refreshCombatLevelsForTickUpdatesOnlyMatchingTickEntriesWithLevels()
+	{
+		ArrayList<FightLogEntry> entries = new ArrayList<>();
+		int[] attackerGear = {1, 2, 3};
+		int[] defenderGear = {4, 5, 6};
+
+		FightLogEntry previousTickEntry = new FightLogEntry(attackerGear, 21, 0.5, 1, 12, defenderGear, "competitor", 103, 1000L);
+		previousTickEntry.setAttackerLevels(new CombatLevels(99, 99, 99, 99, 90, 99));
+
+		FightLogEntry targetTickEntry = new FightLogEntry(attackerGear, 21, 0.5, 1, 12, defenderGear, "competitor", 104, 1200L);
+		targetTickEntry.setAttackerLevels(new CombatLevels(99, 99, 99, 99, 90, 99));
+
+		FightLogEntry targetTickWithoutLevels = new FightLogEntry(attackerGear, 21, 0.5, 1, 12, defenderGear, "competitor", 104, 1300L);
+
+		entries.add(previousTickEntry);
+		entries.add(targetTickEntry);
+		entries.add(targetTickWithoutLevels);
+
+		Fighter.refreshCombatLevelsForTick(entries, 104, new CombatLevels(99, 99, 99, 99, 99, 99));
+
+		assertEquals(90, previousTickEntry.getAttackerLevels().mage);
+		assertEquals(99, targetTickEntry.getAttackerLevels().mage);
+		assertNull(targetTickWithoutLevels.getAttackerLevels());
+	}
+}

--- a/src/test/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalcMagicPrayerTest.java
+++ b/src/test/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalcMagicPrayerTest.java
@@ -1,0 +1,84 @@
+package matsyir.pvpperformancetracker.controllers;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import matsyir.pvpperformancetracker.models.AnimationData;
+import matsyir.pvpperformancetracker.models.EquipmentData;
+import net.runelite.api.SpriteID;
+import org.junit.Test;
+import sun.misc.Unsafe;
+
+import static org.junit.Assert.assertEquals;
+
+public class PvpDamageCalcMagicPrayerTest
+{
+	@Test
+	public void auguryAndVirtusAncientBonusProduceFortyIceBarrageMaxHit() throws Exception
+	{
+		PvpDamageCalc calc = newCalc();
+
+		Method getMagicMaxHit = PvpDamageCalc.class.getDeclaredMethod(
+			"getMagicMaxHit",
+			int.class,
+			AnimationData.class,
+			int.class,
+			EquipmentData.VoidStyle.class,
+			EquipmentData.class,
+			EquipmentData.class,
+			EquipmentData.class,
+			EquipmentData.class,
+			EquipmentData.class);
+		getMagicMaxHit.setAccessible(true);
+
+		getMagicMaxHit.invoke(
+			calc,
+			25,
+			AnimationData.MAGIC_ANCIENT_MULTI_TARGET,
+			SpriteID.PRAYER_AUGURY,
+			EquipmentData.VoidStyle.NONE,
+			null,
+			EquipmentData.ZURIELS_STAFF,
+			null,
+			EquipmentData.VIRTUS_ROBE_TOP,
+			EquipmentData.VIRTUS_ROBE_BOTTOM);
+
+		assertEquals(40, calc.getMaxHit());
+	}
+
+	@Test
+	public void protectionPrayerReducesExpectedDamageButNotDisplayedMaxHit() throws Exception
+	{
+		PvpDamageCalc calc = newCalc();
+		setField(calc, "maxHit", 40);
+		setField(calc, "minHit", 0);
+		setField(calc, "accuracy", 1.0);
+
+		Method getAverageHit = PvpDamageCalc.class.getDeclaredMethod(
+			"getAverageHit",
+			boolean.class,
+			EquipmentData.class,
+			boolean.class);
+		getAverageHit.setAccessible(true);
+
+		getAverageHit.invoke(calc, false, EquipmentData.ZURIELS_STAFF, false);
+
+		assertEquals(12.0, calc.getAverageHit(), 0.0001);
+		assertEquals(40, calc.getMaxHit());
+		assertEquals(0, calc.getMinHit());
+	}
+
+	private static PvpDamageCalc newCalc() throws Exception
+	{
+		Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+		unsafeField.setAccessible(true);
+		Unsafe unsafe = (Unsafe) unsafeField.get(null);
+		return (PvpDamageCalc) unsafe.allocateInstance(PvpDamageCalc.class);
+	}
+
+	private static void setField(PvpDamageCalc calc, String fieldName, Object value) throws Exception
+	{
+		Field field = PvpDamageCalc.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		field.set(calc, value);
+	}
+}


### PR DESCRIPTION
Adds assumed prayers for enemy based off of your personal prayer level to help guide one-sided pov expected damage in the right direction of reality

<img width="766" height="146" alt="image" src="https://github.com/user-attachments/assets/80fc009d-dc8a-45cb-a18b-ae33c246d01c" />
  + Steel Skin for the "Else" column 