### PR TITLE
Fix assumptions for unsynced fights

### DIFF
--- a/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/FightPerformance.java
@@ -212,7 +212,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 			animationData.attackStyle,
 			fightType,
 			AssumedPrayers.localPrayerLevel(PLUGIN.getClient()),
-			competitorLevels.def);
+			PLUGIN.getClient().getRealSkillLevel(Skill.DEFENCE));
 
 		// verify that the player is interacting with their tracked opponent before adding attacks
 		if (eName.equals(competitor.getName()) && Objects.equals(interactingName, opponent.getName()))
@@ -326,7 +326,7 @@ public class FightPerformance implements Comparable<FightPerformance>
 				animationData.attackStyle,
 				fightType,
 				AssumedPrayers.localPrayerLevel(PLUGIN.getClient()),
-				competitorLevels.def);
+				PLUGIN.getClient().getRealSkillLevel(Skill.DEFENCE));
 
 			int offensivePray = PLUGIN.currentlyUsedOffensivePray();
 			competitor.addGhostBarrage(opponent.getPlayer().getOverheadIcon() != animationData.attackStyle.getProtection(),

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
@@ -44,10 +44,6 @@ import matsyir.pvpperformancetracker.models.CombatLevels;
 import net.runelite.api.Skill;
 import matsyir.pvpperformancetracker.models.RangeAmmoData;
 import matsyir.pvpperformancetracker.models.RingData;
-import net.runelite.api.EquipmentInventorySlot;
-import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
-import net.runelite.api.ItemContainer;
 import net.runelite.api.PlayerComposition;
 import net.runelite.api.SpriteID;
 import net.runelite.api.kit.KitType;
@@ -208,10 +204,10 @@ public class PvpDamageCalc
 
 		EquipmentData weapon = EquipmentData.fromId(fixItemId(attackerItems[KitType.WEAPON.getIndex()]));
 
-		int[] playerStats = calculateBonuses(attackerItems, getRingUsed(attacker));
-		int[] opponentStats = calculateBonuses(defenderItems, getRingUsed(defender));
+		int[] playerStats = calculateBonusesWithRing(attackerItems);
+		int[] opponentStats = calculateBonusesWithRing(defenderItems);
 		AnimationData.AttackStyle attackStyle = animationData.attackStyle; // basic style: stab/slash/crush/ranged/magic
-		Integer attackerAmmoItemId = getLocalPlayerAmmoItemId(attacker);
+		Integer attackerAmmoItemId = null;
 
 		// Special attack used will be determined based on the currently used weapon, if its special attack has been implemented.
 		// the animation just serves to tell if they actually did a special attack animation, since some animations
@@ -695,59 +691,6 @@ public class PvpDamageCalc
 		}
 
 		return false;
-	}
-
-	private RingData getRingUsed(Player player)
-	{
-		Integer actualRingItemId = getLocalPlayerRingItemId(player);
-		RingData actualRing = actualRingItemId == null ? null : RingData.fromId(actualRingItemId);
-		return actualRing != null && actualRing != RingData.NONE ? actualRing : ringUsed;
-	}
-
-	private Integer getLocalPlayerRingItemId(Player player)
-	{
-		Player localPlayer = PLUGIN.getClient().getLocalPlayer();
-		if (player == null || localPlayer == null || player.getName() == null || !player.getName().equals(localPlayer.getName()))
-		{
-			return null;
-		}
-
-		ItemContainer worn = PLUGIN.getClient().getItemContainer(InventoryID.EQUIPMENT);
-		if (worn == null)
-		{
-			return null;
-		}
-
-		Item ring = worn.getItem(EquipmentInventorySlot.RING.getSlotIdx());
-		if (ring == null || ring.getId() <= 0)
-		{
-			return null;
-		}
-
-		return ring.getId();
-	}
-
-	private Integer getLocalPlayerAmmoItemId(Player attacker)
-	{
-		Player localPlayer = PLUGIN.getClient().getLocalPlayer();
-		if (attacker == null || localPlayer == null || attacker.getName() == null || !attacker.getName().equals(localPlayer.getName()))
-		{
-			return null;
-		}
-
-		ItemContainer worn = PLUGIN.getClient().getItemContainer(InventoryID.EQUIPMENT);
-		if (worn == null)
-		{
-			return null;
-		}
-
-		Item ammo = worn.getItem(EquipmentInventorySlot.AMMO.getSlotIdx());
-		if (ammo == null || ammo.getId() <= 0)
-		{
-			return null;
-		}
-
-		return ammo.getId();
 	}
 
 	private void getRangedMaxHit(int rangeStrength, boolean usingSpec, EquipmentData weapon, VoidStyle voidStyle, int offensivePray, int[] attackerComposition, AnimationData animationData, Integer attackerAmmoItemId)

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
@@ -44,6 +44,10 @@ import matsyir.pvpperformancetracker.models.CombatLevels;
 import net.runelite.api.Skill;
 import matsyir.pvpperformancetracker.models.RangeAmmoData;
 import matsyir.pvpperformancetracker.models.RingData;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.PlayerComposition;
 import net.runelite.api.SpriteID;
 import net.runelite.api.kit.KitType;
@@ -204,8 +208,8 @@ public class PvpDamageCalc
 
 		EquipmentData weapon = EquipmentData.fromId(fixItemId(attackerItems[KitType.WEAPON.getIndex()]));
 
-		int[] playerStats = calculateBonusesWithRing(attackerItems);
-		int[] opponentStats = calculateBonusesWithRing(defenderItems);
+		int[] playerStats = calculateBonuses(attackerItems, getRingUsed(attacker));
+		int[] opponentStats = calculateBonuses(defenderItems, getRingUsed(defender));
 		AnimationData.AttackStyle attackStyle = animationData.attackStyle; // basic style: stab/slash/crush/ranged/magic
 		Integer attackerAmmoItemId = null;
 
@@ -691,6 +695,36 @@ public class PvpDamageCalc
 		}
 
 		return false;
+	}
+
+	private RingData getRingUsed(Player player)
+	{
+		Integer actualRingItemId = getLocalPlayerRingItemId(player);
+		RingData actualRing = actualRingItemId == null ? null : RingData.fromId(actualRingItemId);
+		return actualRing != null && actualRing != RingData.NONE ? actualRing : ringUsed;
+	}
+
+	private Integer getLocalPlayerRingItemId(Player player)
+	{
+		Player localPlayer = PLUGIN.getClient().getLocalPlayer();
+		if (player == null || localPlayer == null || player.getName() == null || !player.getName().equals(localPlayer.getName()))
+		{
+			return null;
+		}
+
+		ItemContainer worn = PLUGIN.getClient().getItemContainer(InventoryID.EQUIPMENT);
+		if (worn == null)
+		{
+			return null;
+		}
+
+		Item ring = worn.getItem(EquipmentInventorySlot.RING.getSlotIdx());
+		if (ring == null || ring.getId() <= 0)
+		{
+			return null;
+		}
+
+		return ring.getId();
 	}
 
 	private void getRangedMaxHit(int rangeStrength, boolean usingSpec, EquipmentData weapon, VoidStyle voidStyle, int offensivePray, int[] attackerComposition, AnimationData animationData, Integer attackerAmmoItemId)

--- a/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
+++ b/src/main/java/matsyir/pvpperformancetracker/controllers/PvpDamageCalc.java
@@ -217,7 +217,7 @@ public class PvpDamageCalc
 
 		// Assume defender prayers match local prayer unlocks (opponent prayers are not visible).
 		int localPrayerLevel = PLUGIN.getClient().getRealSkillLevel(Skill.PRAYER);
-		int localDefenceLevel = this.attackerLevels.def;
+		int localDefenceLevel = PLUGIN.getClient().getRealSkillLevel(Skill.DEFENCE);
 		double defencePrayerModifier = AssumedPrayers.assumedDefencePrayerModifier(attackStyle, localPrayerLevel, localDefenceLevel);
 		boolean defensiveAugurySuccess = AssumedPrayers.assumedDefensiveAugury(localPrayerLevel, localDefenceLevel);
 


### PR DESCRIPTION
Just a couple more fixes to get the calcs back to the intended symmetry, where each side uses the assumptions, rather than actual observed gear:
- Use actual defence level rather than boosted to determine offensive prayer unlocks. Currently, defence boosts/drains could change the assumed offensive prayers during a fight.
- Use config ring/ammo slots when fight is unsynced.